### PR TITLE
As of Rubygems 1.7.0, `Gem::Specification#has_rdoc=` has been deprecated

### DIFF
--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.date = '2011-05-06'
   s.email = 'vicent@github.com'
   s.homepage = 'http://github.com/tanoku/redcarpet'
-  s.has_rdoc = true
   s.authors = ["Natacha Porté", "Vicent Martí"]
   # = MANIFEST =
   s.files = %w[


### PR DESCRIPTION
`has_rdoc=` has been deprecated (see http://blog.segment7.net/2011/04/01/rubygems-1-7-0 for example). So it's better to remove it to avoid future breakage.
