### PR TITLE
Fix toc_content when some levels of headers are missing

### DIFF
--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -511,19 +511,19 @@ toc_header(struct buf *ob, struct buf *text, int level, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
-	if (level > options->toc_data.current_level) {
-		if (level > 1)
+	while (level > options->toc_data.current_level) {
+		if (options->toc_data.current_level > 0)
 			BUFPUTSL(ob, "<li>");
 		BUFPUTSL(ob, "<ul>\n");
+		options->toc_data.current_level++;
 	}
 	
-	if (level < options->toc_data.current_level) {
+	while (level < options->toc_data.current_level) {
 		BUFPUTSL(ob, "</ul>");
 		if (options->toc_data.current_level > 1)
 			BUFPUTSL(ob, "</li>\n");
+		options->toc_data.current_level--;
 	}
-
-	options->toc_data.current_level = level;
 
 	bufprintf(ob, "<li><a href=\"#toc_%d\">", options->toc_data.header_count++);
 	if (text)


### PR DESCRIPTION
Hi,

the `toc_content` output is not correct when some levels of headers are missing. For example:

``` ruby
Redcarpet.new("## Foobar ##").toc_content
  # => "<li><ul>\n<li><a href=\"#toc_0\">Foobar</a></li>\n</ul></li>\n</ul>\n"

Redcarpet.new("# One #\n## Two ##\n### Three ###\n# Foobar #").toc_content
  # => "<ul>\n<li><a href=\"#toc_0\">One</a></li>\n<li><ul>\n<li><a href=\"#toc_1\">Two</a></li>\n<li><ul>\n<li><a href=\"#toc_2\">Three</a></li>\n</ul></li>\n<li><a href=\"#toc_3\">Foobar</a></li>\n</ul>\n"
```

As you can see, the HTML is not valid on these examples. On the first, there should be an `<ul>` at the start. On the second, one level of closing tags, `</ul></li>`, is missing between _Three_ and _Foobar_.
