### PR TITLE
add copyright notice to ISC license

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,9 @@ and behavior as the RDiscount library, which acts as a drop-in replacement.
 License
 -------
 
-Permission to use, copy, modify, and distribute this software for any
+Copyright (c) 2011, Vicent Martí
+
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
The license is missing the copyright notice it references (_the above copyright notice_):

> Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.

You could add `Copyright (c) 2011, Vicent Martí` like in this [ISC license example](http://en.wikipedia.org/wiki/ISC_license) but without the email address.

I also added the and/or change [proposed by the FSF](http://en.wikipedia.org/wiki/ISC_license). Not sure I agree with the FSF that it was ambiguous in the first place, but the [Internet Software Consortium](http://en.wikipedia.org/wiki/Internet_Systems_Consortium), who wrote the license, added it.

Nice library!
