### PR TITLE
support ruby 1.9.2p180

### DIFF
--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Gem::Specification.new do |s|
   s.name = 'redcarpet'
   s.version = '2.0.0b3'


### PR DESCRIPTION
I had an error under Mac OSX 1.9.2p180 :

/Users/Mike/.rvm/gems/ruby-1.9.2-p180@zorpress/gems/bundler-1.0.18/lib/bundler.rb:239:in `eval': /Users/Mike/.rvm/gems/ruby-1.9.2-p180@zorpress/bundler/gems/redcarpet-7b3f3b143800/redcarpet.gemspec:9: invalid multibyte char (US-ASCII) (SyntaxError)
/Users/Mike/.rvm/gems/ruby-1.9.2-p180@zorpress/bundler/gems/redcarpet-7b3f3b143800/redcarpet.gemspec:9: invalid multibyte char (US-ASCII)
/Users/Mike/.rvm/gems/ruby-1.9.2-p180@zorpress/bundler/gems/redcarpet-7b3f3b143800/redcarpet.gemspec:9: syntax error, unexpected $end, expecting ']'
  s.authors = ["Natacha Porté", "Vicent Martí"]

It seems resolved for 1.9.2p290.

My fix makes it work on p180 as well,

Cheers !
