### PR TITLE
render_man: fix nil error in normal_text()

### DIFF
--- a/lib/redcarpet/render_man.rb
+++ b/lib/redcarpet/render_man.rb
@@ -3,7 +3,7 @@ module Redcarpet
     class ManPage < Base
 
       def normal_text(text)
-        text.gsub('-', '\\-').strip
+        text.gsub(/(?<=\W)-(?=\W)/, '\\-') if text
       end
 
       def block_code(code, language)


### PR DESCRIPTION
This commit fixes the following run-time error:

```
redcarpet-2.0.0b5/lib/redcarpet/render_man.rb:6:in `normal_text':
undefined method `gsub' for nil:NilClass (NoMethodError)
```

Which is caused by processing the following document:

```
name(1) -- short, single-sentence description
=============================================

`name` [<optional>...] <flags>
```

It also fixes the removal of whitespace in text segments and the
propagation of line breaks from the source document to the output.

Cheers.
