### PR TITLE
change Redcarpet::VERSION to 2.0.0

### DIFF
--- a/lib/redcarpet.rb
+++ b/lib/redcarpet.rb
@@ -1,7 +1,7 @@
 require 'redcarpet.so'
 
 module Redcarpet
-  VERSION = '2.0.0b5'
+  VERSION = '2.0.0'
 
   class Markdown
     attr_reader :renderer


### PR DESCRIPTION
Congratulates on Release! I've been waiting for it for a long time!

But did you forgot to change `Redcarpet::VERSION` ?

Here comes a patch :)
