### PR TITLE
Added render_strip to the gemspec.

### DIFF
--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
     lib/redcarpet.rb
     lib/redcarpet/compat.rb
     lib/redcarpet/render_man.rb
+    lib/redcarpet/render_strip.rb
     redcarpet.gemspec
     sundown
     test/redcarpet_test.rb


### PR DESCRIPTION
I was really freaking confused when I tried to require render_strip to get some plaintext output. I checked my local gem install and the file wasn't there. Went back and forth to GitHub a few times, double checking everything... then realized it wasn't in the gemspec.
