### PR TITLE
generate_toc is the old name and with_toc_data the new name

### DIFF
--- a/lib/redcarpet.rb
+++ b/lib/redcarpet.rb
@@ -86,7 +86,7 @@ class RedcarpetCompat
     :space_header => :space_after_headers,
     :strikethrough => :strikethrough,
     :tables => :tables,
-    :with_toc_data => :generate_toc,
+    :generate_toc => :with_toc_data,
     :xhtml => :xhtml,
     # old names with no new mapping
     :gh_blockcode => nil,


### PR DESCRIPTION
Hi,

I think that :generate_toc and :with_toc_data was in the bad order.
