### PR TITLE
Allow commandline usage of SmartyHTML

### DIFF
--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
-# Usage: redcarpet [--parse-<extension>...] [--render-<extension>...] [<file>...]
+# Usage: redcarpet [--parse-<extension>...] [--render-<extension>...] [--smarty] [<file>...]
 # Convert one or more Markdown files to HTML and write to standard output. With
 # no <file> or when <file> is '-', read Markdown source text from standard input.
 # With <extension>s, perform additional Markdown processing before writing output.
+# With --smarty, use the SmartyHTML renderer
 if ARGV.include?('--help')
   File.read(__FILE__).split("\n").grep(/^# /).each do |line|
     puts line[2..-1]
@@ -17,6 +18,7 @@ require 'redcarpet'
 
 render_extensions = {}
 parse_extensions = {}
+renderer = Redcarpet::Render::HTML
 
 ARGV.delete_if do |arg|
   if arg =~ /^--render-([\w-]+)$/
@@ -25,10 +27,12 @@ ARGV.delete_if do |arg|
   elsif arg =~ /^--parse-([\w-]+)$/
     arg = $1.gsub('-', '_')
     parse_extensions[arg.to_sym] = true
+  elsif arg == '--smarty'
+    renderer = Redcarpet::Render::SmartyHTML
   else
     false
   end
 end
 
-render = Redcarpet::Render::HTML.new(render_extensions)
+render = renderer.new(render_extensions)
 STDOUT.write(Redcarpet::Markdown.new(render, parse_extensions).render(ARGF.read))


### PR DESCRIPTION
Because it makes the typography look that bit nicer and this way is easier than maintaining my own script which uses that by default.
