### PR TITLE
Handle a renderer returning nil from preprocess.

### DIFF
--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -104,6 +104,8 @@ static VALUE rb_redcarpet_md_render(VALUE self, VALUE text)
 
 	if (rb_respond_to(rb_rndr, rb_intern("preprocess")))
 		text = rb_funcall(rb_rndr, rb_intern("preprocess"), 1, text);
+  if (NIL_P(text))
+    return Qnil;
 
 #ifdef HAVE_RUBY_ENCODING_H
 	{

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -328,6 +328,18 @@ class CustomRenderTest < Test::Unit::TestCase
     html_equal "<p>This is <em class=\"cool\">just</em> a test</p>",
       md.render("This is *just* a test")
   end
+
+  class NilPreprocessRenderer < Redcarpet::Render::HTML
+    def preprocess(fulldoc)
+      nil
+    end
+  end
+
+  def test_preprocess_returning_nil
+    md = Redcarpet::Markdown.new(NilPreprocessRenderer)
+    assert_equal(nil,md.render("Anything"))
+  end
+
 end
 
 class RedcarpetCompatTest < Test::Unit::TestCase


### PR DESCRIPTION
No longer segfaults, fixes #71.

Not sure if it would be better to return an empty string in this case... but really there is no real use case for having a preprocess return nil in the first place.
