### PR TITLE
Add :link_attributes option to the HTML renderer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -148,6 +148,7 @@ instantiating the renderer:
         :xhtml - output XHTML-conformant tags. This option is always enabled in the
             `Render::XHTML` renderer.
 
+        :link_attributes - hash of extra attributes to add to links
 
     Example:
 

--- a/ext/redcarpet/redcarpet.h
+++ b/ext/redcarpet/redcarpet.h
@@ -3,6 +3,7 @@
 
 #define RSTRING_NOT_MODIFIED
 #include "ruby.h"
+#include "st.h"
 #include <stdio.h>
 
 #ifdef HAVE_RUBY_ENCODING_H
@@ -21,6 +22,7 @@ extern void Init_redcarpet_rndr();
 
 struct redcarpet_renderopt {
 	struct html_renderopt html;
+	VALUE link_attributes;
 	VALUE self;
 	VALUE base_class;
 #ifdef HAVE_RUBY_ENCODING_H
@@ -31,6 +33,7 @@ struct redcarpet_renderopt {
 struct rb_redcarpet_rndr {
 	struct sd_callbacks callbacks;
 	struct redcarpet_renderopt options;
+	struct buf *ob;
 };
 
 #endif


### PR DESCRIPTION
As suggested on #122 this adds a new HTML renderer option, `:link_attributes`, which takes a hash of extra attributes to be added to all links.

I'm no ruby/C integration expert, so there may well be better ways to do some of it...
