### PR TITLE
2.2.1 installation breaks on Ubuntu ruby 1.8

### DIFF
--- a/ext/redcarpet/extconf.rb
+++ b/ext/redcarpet/extconf.rb
@@ -2,3 +2,5 @@ require 'mkmf'
 
 dir_config('redcarpet')
 create_makefile('redcarpet')
+
+have_header 'ruby/st.h' or have_header 'st.h' or abort "redcarpet requires the ruby/st.h header"

--- a/ext/redcarpet/redcarpet.h
+++ b/ext/redcarpet/redcarpet.h
@@ -3,7 +3,14 @@
 
 #define RSTRING_NOT_MODIFIED
 #include "ruby.h"
-#include "ruby/st.h"
+
+
+#ifdef HAVE_RUBY_ST_H
+#       include "ruby/st.h"
+#else
+#       include "st.h"
+#endif
+
 #include <stdio.h>
 
 #ifdef HAVE_RUBY_ENCODING_H


### PR DESCRIPTION
On ubuntu and ruby 1.8, st.h is installed /usr/lib/ruby/1.8/i686-linux/st.h,  so the line "#include ruby/st.h" does not work. This pull request fix that by doing a header detecting first, if it is ruby1.9 include "ruby/st.h"
otherwise try "st.h".

My ubuntu version: Ubuntu 12.04 LTS
Ruby version: ruby 1.8.7 (2011-06-30 patchlevel 352) [i686-linux](directly installed from apt-get)

``` console
$ sudo gem install redcarpet
Fetching: redcarpet-2.2.1.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing redcarpet:
    ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.8 extconf.rb
creating Makefile

make
gcc -I. -I/usr/lib/ruby/1.8/i686-linux -I/usr/lib/ruby/1.8/i686-linux -I. -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64  -fPIC -fno-strict-aliasing -g -g -O2  -fPIC   -c html.c
gcc -I. -I/usr/lib/ruby/1.8/i686-linux -I/usr/lib/ruby/1.8/i686-linux -I. -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64  -fPIC -fno-strict-aliasing -g -g -O2  -fPIC   -c stack.c
gcc -I. -I/usr/lib/ruby/1.8/i686-linux -I/usr/lib/ruby/1.8/i686-linux -I. -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64  -fPIC -fno-strict-aliasing -g -g -O2  -fPIC   -c houdini_html_e.c
gcc -I. -I/usr/lib/ruby/1.8/i686-linux -I/usr/lib/ruby/1.8/i686-linux -I. -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64  -fPIC -fno-strict-aliasing -g -g -O2  -fPIC   -c autolink.c
gcc -I. -I/usr/lib/ruby/1.8/i686-linux -I/usr/lib/ruby/1.8/i686-linux -I. -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64  -fPIC -fno-strict-aliasing -g -g -O2  -fPIC   -c buffer.c
gcc -I. -I/usr/lib/ruby/1.8/i686-linux -I/usr/lib/ruby/1.8/i686-linux -I. -D_FORTIFY_SOURCE=2 -D_FILE_OFFSET_BITS=64  -fPIC -fno-strict-aliasing -g -g -O2  -fPIC   -c rc_render.c
In file included from rc_render.c:17:0:
redcarpet.h:6:21: fatal error: ruby/st.h: No such file or directory
compilation terminated.
make: *** [rc_render.o] Error 1

Gem files will remain installed in /var/lib/gems/1.8/gems/redcarpet-2.2.1 for inspection.
Results logged to /var/lib/gems/1.8/gems/redcarpet-2.2.1/ext/redcarpet/gem_make.out

```
