### PR TITLE
Add option to ignore usual indented code blocks.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,6 +75,12 @@ characters. Autolinks for the http, https and ftp protocols will be
 automatically detected. Email addresses are also handled, and http
 links without protocol, but starting with `www`.
 
+* `:disable_indented_code_blocks`: do not parse usual markdown
+code blocks. Markdown converts text with four spaces at
+the front of each line to code blocks. This options
+prevents it from doing so. Recommended to use
+with `fenced_code_blocks: true`.
+
 * `:strikethrough`: parse strikethrough, PHP-Markdown style
 Two `~` characters mark the start of a strikethrough,
 e.g. `this is ~~good~~ bad`

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2230,7 +2230,7 @@ parse_block(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 		else if (prefix_quote(txt_data, end))
 			beg += parse_blockquote(ob, rndr, txt_data, end);
 
-		else if (prefix_code(txt_data, end))
+		else if (!(rndr->ext_flags & MKDEXT_DISABLE_INDENTED_CODE) && prefix_code(txt_data, end))
 			beg += parse_blockcode(ob, rndr, txt_data, end);
 
 		else if (prefix_uli(txt_data, end))

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -59,6 +59,7 @@ enum mkd_extensions {
 	MKDEXT_SPACE_HEADERS = (1 << 6),
 	MKDEXT_SUPERSCRIPT = (1 << 7),
 	MKDEXT_LAX_SPACING = (1 << 8),
+	MKDEXT_DISABLE_INDENTED_CODE = (1 << 9),
 };
 
 /* sd_callbacks - functions for rendering parsed data */

--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -38,6 +38,9 @@ static void rb_redcarpet_md_flags(VALUE hash, unsigned int *enabled_extensions_p
 	if (rb_hash_lookup(hash, CSTR2SYM("fenced_code_blocks")) == Qtrue)
 		extensions |= MKDEXT_FENCED_CODE;
 
+	if (rb_hash_lookup(hash, CSTR2SYM("disable_indented_code_blocks")) == Qtrue)
+		extensions |= MKDEXT_DISABLE_INDENTED_CODE;
+
 	if (rb_hash_lookup(hash, CSTR2SYM("autolink")) == Qtrue)
 		extensions |= MKDEXT_AUTOLINK;
 

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -342,6 +342,20 @@ fenced
     assert !out.include?("<pre><code>")
   end
 
+  def test_that_indented_flag_works
+    text = <<indented
+This is a simple text
+
+    This is some awesome code
+    with shit
+
+And this is again a simple text
+indented
+
+    assert render_with({}, text) =~ /<code/
+    assert render_with({:disable_indented_code_blocks => true}, text) !~ /<code/
+  end
+
   def test_that_headers_are_linkable
     markdown = @markdown.render('### Hello [GitHub](http://github.com)')
     html_equal "<h3>Hello <a href=\"http://github.com\">GitHub</a></h3>\n", markdown


### PR DESCRIPTION
Markdown converts text with four spaces at the front of each line to code blocks. Of course we should support that, but when using fenced code blocks, indented one can even be harmful. There should be a way to turn them off.

This patch adds option to disable indented code blocks.
