### PR TITLE
Add redcarpet_ prefix for stack_* functions

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -135,7 +135,7 @@ rndr_newbuf(struct sd_markdown *rndr, int type)
 		work->size = 0;
 	} else {
 		work = bufnew(buf_size[type]);
-		stack_push(pool, work);
+		redcarpet_stack_push(pool, work);
 	}
 
 	return work;
@@ -2410,8 +2410,8 @@ sd_markdown_new(
 
 	memcpy(&md->cb, callbacks, sizeof(struct sd_callbacks));
 
-	stack_init(&md->work_bufs[BUFFER_BLOCK], 4);
-	stack_init(&md->work_bufs[BUFFER_SPAN], 8);
+	redcarpet_stack_init(&md->work_bufs[BUFFER_BLOCK], 4);
+	redcarpet_stack_init(&md->work_bufs[BUFFER_SPAN], 8);
 
 	memset(md->active_char, 0x0, 256);
 
@@ -2539,8 +2539,8 @@ sd_markdown_free(struct sd_markdown *md)
 	for (i = 0; i < (size_t)md->work_bufs[BUFFER_BLOCK].asize; ++i)
 		bufrelease(md->work_bufs[BUFFER_BLOCK].item[i]);
 
-	stack_free(&md->work_bufs[BUFFER_SPAN]);
-	stack_free(&md->work_bufs[BUFFER_BLOCK]);
+	redcarpet_stack_free(&md->work_bufs[BUFFER_SPAN]);
+	redcarpet_stack_free(&md->work_bufs[BUFFER_BLOCK]);
 
 	free(md);
 }

--- a/ext/redcarpet/stack.c
+++ b/ext/redcarpet/stack.c
@@ -2,7 +2,7 @@
 #include <string.h>
 
 int
-stack_grow(struct stack *st, size_t new_size)
+redcarpet_stack_grow(struct stack *st, size_t new_size)
 {
 	void **new_st;
 
@@ -26,7 +26,7 @@ stack_grow(struct stack *st, size_t new_size)
 }
 
 void
-stack_free(struct stack *st)
+redcarpet_stack_free(struct stack *st)
 {
 	if (!st)
 		return;
@@ -39,7 +39,7 @@ stack_free(struct stack *st)
 }
 
 int
-stack_init(struct stack *st, size_t initial_size)
+redcarpet_stack_init(struct stack *st, size_t initial_size)
 {
 	st->item = NULL;
 	st->size = 0;
@@ -48,11 +48,11 @@ stack_init(struct stack *st, size_t initial_size)
 	if (!initial_size)
 		initial_size = 8;
 
-	return stack_grow(st, initial_size);
+	return redcarpet_stack_grow(st, initial_size);
 }
 
 void *
-stack_pop(struct stack *st)
+redcarpet_stack_pop(struct stack *st)
 {
 	if (!st->size)
 		return NULL;
@@ -61,9 +61,9 @@ stack_pop(struct stack *st)
 }
 
 int
-stack_push(struct stack *st, void *item)
+redcarpet_stack_push(struct stack *st, void *item)
 {
-	if (stack_grow(st, st->size * 2) < 0)
+	if (redcarpet_stack_grow(st, st->size * 2) < 0)
 		return -1;
 
 	st->item[st->size++] = item;
@@ -71,7 +71,7 @@ stack_push(struct stack *st, void *item)
 }
 
 void *
-stack_top(struct stack *st)
+redcarpet_stack_top(struct stack *st)
 {
 	if (!st->size)
 		return NULL;

--- a/ext/redcarpet/stack.h
+++ b/ext/redcarpet/stack.h
@@ -13,14 +13,14 @@ struct stack {
 	size_t asize;
 };
 
-void stack_free(struct stack *);
-int stack_grow(struct stack *, size_t);
-int stack_init(struct stack *, size_t);
+void redcarpet_stack_free(struct stack *);
+int redcarpet_stack_grow(struct stack *, size_t);
+int redcarpet_stack_init(struct stack *, size_t);
 
-int stack_push(struct stack *, void *);
+int redcarpet_stack_push(struct stack *, void *);
 
-void *stack_pop(struct stack *);
-void *stack_top(struct stack *);
+void *redcarpet_stack_pop(struct stack *);
+void *redcarpet_stack_top(struct stack *);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The current redcarpet cannot be used together with ruby-prof because of occurring segmentation fault.  The reason why segv is occurred is that redcarpet and ruby-prof have functions with the same names, such as stack_push.  When you load ruby-prof before loading redcarpet, redcarpet internally uses ruby-prof's stack functions.

I think both libraries should change these generic names to library-specific names.
