### PR TITLE
Git ignore tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-lib/redcarpet.bundle
+/lib/redcarpet.bundle
+/tmp


### PR DESCRIPTION
I was about to submit a separate pull-request, but ran into this first. The `tmp` directory is filled with compiled libs during a build. Seemed like a good thing to add to the .gitignore, just in case someone doesn't already have `tmp` ignored in their global .gitignore file.
