### PR TITLE
Add support for org-table syntax

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2102,7 +2102,7 @@ parse_table_header(
 		while (i < under_end && data[i] == ' ')
 			i++;
 
-		if (i < under_end && data[i] != '|')
+		if (i < under_end && data[i] != '|' && data[i] != '+')
 			break;
 
 		if (dashes < 3)

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -294,6 +294,18 @@ EOS
     assert render_with({:tables => true}, text) =~ /<table/
   end
 
+  def test_that_tables_work_with_org_table_syntax
+    text = <<EOS
+| aaa | bbbb |
+|-----+------|
+|hello|sailor|
+EOS
+
+    assert render_with({}, text) !~ /<table/
+
+    assert render_with({:tables => true}, text) =~ /<table/
+  end
+
   def test_strikethrough_flag_works
     text = "this is ~some~ striked ~~text~~"
 


### PR DESCRIPTION
This just adds support for alternatively using a plus (`+`) as an intersection character instead of requiring pipes (`|`) when drawing the header dashes of a table. The emacs org-mode table automatically manages ascii tables, but requires the use of pluses for line intersections. I think it would be great if markdown tables could support this syntax as well.

Here's an example of a table in org-table syntax. The only difference from the already-supported markdown table syntax is the use of pluses instead of pipes in the header dash line.

```
| Column A | Column B | Column C |
|----------+----------+----------|
| Cell A1  | Cell B1  | Cell C1  |
| Cell A2  | Cell B2  | Cell C2  |
| Cell A3  | Cell B3  | Cell C3  |
```

Which would produce this:

| Column A | Column B | Column C |
| --- | --- | --- |
| Cell A1 | Cell B1 | Cell C1 |
| Cell A2 | Cell B2 | Cell C2 |
| Cell A3 | Cell B3 | Cell C3 |
