### PR TITLE
WIP: Add Redcarpet::Markdown#initialize_copy

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2551,6 +2551,17 @@ sd_version(int *ver_major, int *ver_minor, int *ver_revision)
 	*ver_major = SUNDOWN_VER_MAJOR;
 	*ver_minor = SUNDOWN_VER_MINOR;
 	*ver_revision = SUNDOWN_VER_REVISION;
+
+void
+sd_markdown_copy(struct sd_markdown *self, struct sd_markdown *orig) {
+	memcpy(&self->cb, &orig->cb, sizeof(struct sd_callbacks));
+	self->opaque = orig->opaque;
+	memcpy(self->active_char, orig->active_char, 256);
+	memcpy(&self->work_bufs[0], &orig->work_bufs[0], orig->work_bufs[0].size);
+	memcpy(&self->work_bufs[1], &orig->work_bufs[1], orig->work_bufs[1].size);
+	self->ext_flags = orig->ext_flags;
+	self->max_nesting = orig->max_nesting;
+	self->in_link_body = orig->in_link_body;
 }
 
 /* vim: set filetype=c: */

--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -136,12 +136,28 @@ static VALUE rb_redcarpet_md_render(VALUE self, VALUE text)
 	return text;
 }
 
+static VALUE
+rb_redcarpet_md_init_copy(VALUE self, VALUE orig)
+{
+	struct sd_markdown *sdm_self, *sdm_orig;
+	Data_Get_Struct(self, struct sd_markdown, sdm_self);
+	if (TYPE(orig) != T_DATA ||
+	RDATA(orig)->dfree != (RUBY_DATA_FUNC)rb_redcarpet_md__free) {
+	rb_raise(rb_eTypeError, "Redcarpet::Markdown#initialize_copy called with wrong object");
+	}
+	/* assert(sdm_self); // => failed */
+	Data_Get_Struct(orig, struct sd_markdown, sdm_orig);
+	sd_markdown_copy(sdm_self, sdm_orig);
+	return Qnil;
+}
+
 void Init_redcarpet()
 {
     rb_mRedcarpet = rb_define_module("Redcarpet");
 
 	rb_cMarkdown = rb_define_class_under(rb_mRedcarpet, "Markdown", rb_cObject);
     rb_define_singleton_method(rb_cMarkdown, "new", rb_redcarpet_md__new, -1);
+    rb_define_method(rb_cMarkdown, "initialize_copy", rb_redcarpet_md_init_copy, 1);
     rb_define_method(rb_cMarkdown, "render", rb_redcarpet_md_render, 1);
 
 	Init_redcarpet_rndr();


### PR DESCRIPTION
I tried to implement `Redcarpet::markdown#initialize` to make
`markdown.dup` and `markdown.clone` work, but I couldn't.
(`markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)`)

Somehow `Data_Get_Struct(self, struct sd_markdown, sdm_self);`
at ext/redcarpet/rc_markdown.c:143 assign null into `sdm_self`
when `markdown.dup` is called.
`markdown.send(:initialize_copy, markdown2)` works though.

Could you give advices to me?
