### PR TITLE
SmartyPants: Preserve single `backticks` in HTML

### DIFF
--- a/ext/redcarpet/html_smartypants.c
+++ b/ext/redcarpet/html_smartypants.c
@@ -221,6 +221,7 @@ smartypants_cb__backtick(struct buf *ob, struct smartypants_data *smrt, uint8_t 
 			return 1;
 	}
 
+	bufputc(ob, text[0]);
 	return 0;
 }
 

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -50,6 +50,11 @@ class SmartyPantsTest < Test::Unit::TestCase
     rd = @pants.render("<p>what'd you say?</p>")
     assert_equal "<p>what&rsquo;d you say?</p>", rd
   end
+
+  def test_that_backticks_are_preserved
+    rd = @pants.render("<p>single `backticks` in HTML should be preserved</p>")
+    assert_equal "<p>single `backticks` in HTML should be preserved</p>", rd
+  end
 end
 
 class HTMLRenderTest < Test::Unit::TestCase


### PR DESCRIPTION
When SmartyPants is processing HTML (yes HTML, not Markdown), single
backticks should be left intact.  Previously they were being deleted.
