### PR TITLE
Remove Gemfile.lock from the gemspec

### DIFF
--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.files = %w[
     COPYING
     Gemfile
-    Gemfile.lock
     README.markdown
     Rakefile
     bin/redcarpet


### PR DESCRIPTION
Keeps the initial `bundle` run from failing.
