### PR TITLE
Fix invalid utf-8 sequence when autolinking email

### DIFF
--- a/ext/redcarpet/autolink.c
+++ b/ext/redcarpet/autolink.c
@@ -238,7 +238,7 @@ sd_autolink__email(
 	if (link_end < 2 || nb != 1 || np == 0)
 		return 0;
 
-	link_end = autolink_delim(data, link_end, max_rewind, size);
+	link_end = autolink_delim(data, link_end - 1, max_rewind, size);
 
 	if (link_end == 0)
 		return 0;

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -263,6 +263,12 @@ class MarkdownTest < Test::Unit::TestCase
     html_equal exp, rd
   end
 
+  def test_multibyte_char_after_mail_addresses
+    rd = render_with({:autolink => true}, "example@example.com\u3042")
+    exp = %{<p><a href=\"mailto:example@example.com\">example@example.com</a>\u3042</p>}
+    html_equal exp, rd
+  end
+
   def test_memory_leak_when_parsing_char_links
     @markdown.render(<<-leaks)
 2. Identify the wild-type cluster and determine all clusters


### PR DESCRIPTION
Fix invalid utf-8 sequence when email address string followed by multibyte utf-8 character.
