### PR TITLE
Mark all symbols as hidden except the main entry point

### DIFF
--- a/ext/redcarpet/extconf.rb
+++ b/ext/redcarpet/extconf.rb
@@ -1,4 +1,6 @@
 require 'mkmf'
 
+$CFLAGS << ' -fvisibility=hidden'
+
 dir_config('redcarpet')
 create_makefile('redcarpet')

--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -136,6 +136,7 @@ static VALUE rb_redcarpet_md_render(VALUE self, VALUE text)
 	return text;
 }
 
+__attribute__((visibility("default")))
 void Init_redcarpet()
 {
     rb_mRedcarpet = rb_define_module("Redcarpet");


### PR DESCRIPTION
This avoids conflicts with other gems that may have some of the same symbols, such as escape_utils which also uses houdini.

Mirror of https://github.com/brianmario/escape_utils/pull/32 which covers the same issue on the escape_utils site.
