### PR TITLE
Ensure StripDown render adds new line characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Version 2.3.0
 
+* Ensure new lines characters are inserted when using the StripDown
+render. *Robin Dupret*
+
 * Mark all symbols as hidden except the main entry point *Tom Hughes*
 
   This avoids conflicts with other gems that may have some of the

--- a/lib/redcarpet/render_strip.rb
+++ b/lib/redcarpet/render_strip.rb
@@ -8,8 +8,7 @@ module Redcarpet
       [
         # block-level calls
         :block_code, :block_quote,
-        :block_html, :header, :list,
-        :list_item, :paragraph,
+        :block_html, :list, :list_item,
 
         # span-level calls
         :autolink, :codespan, :double_emphasis,
@@ -28,6 +27,14 @@ module Redcarpet
       # Other methods where the text content is in another argument
       def link(link, title, content)
         content
+      end
+
+      def paragraph(text)
+        text + "\n"
+      end
+
+      def header(text, header_level)
+        text + "\n"
       end
     end
   end

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -8,6 +8,7 @@ end
 gem "test-unit", ">=2" # necessary when not using bundle exec
 require 'test/unit'
 require 'redcarpet'
+require 'redcarpet/render_strip'
 require 'redcarpet/render_man'
 require 'nokogiri'
 
@@ -450,6 +451,35 @@ class RedcarpetCompatTest < Test::Unit::TestCase
     exts = [:gh_blockcode, :no_tables, :smart, :strict]
     html = RedcarpetCompat.new('"TEST"', *exts).to_html
     html_equal "<p>&quot;TEST&quot;</p>\n", html
+  end
+end
+
+class StripDownRender < Test::Unit::TestCase
+
+  def setup
+    @markdown = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+  end
+
+  def test_basics
+    markdown = <<-Markdown
+# [Foo bar](https://github.com)
+Markdown
+    html = @markdown.render(markdown)
+    html_equal "Foo bar\n", html
+  end
+
+  def test_insert_new_lines_char
+    markdown = <<-Markdown
+# Foo bar
+
+Hello world! Please visit [this site](https://github.com/).
+
+    class Foo
+    end
+Markdown
+
+    html = @markdown.render(markdown)
+    html_equal "Foo bar\nHello world! Please visit this site.\nclass Foo\nend\n", html
   end
 end
 


### PR DESCRIPTION
Hello,

This pull request fix #175. When using the StripDown render, special new lines characters (\n) weren't added for paragraphs. Also enable this for headers.

I just add a simple test case for this I'm not sure if it's enough. All tests are green on my machine. I hope the travis matrix will be too!

Have a nice day.
