### PR TITLE
Add a autolink_with_nofollow option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Version 2.3.0
 
+* Add a `:autolink_with_nofollow` option *Robin Dupret*
+
 * Add a `:disable_indented_code_blocks` option *Dmitriy Kiriyenko*
 
 * Fix issue [#57](https://github.com/vmg/redcarpet/issues/57) *Mike Morearty*

--- a/README.markdown
+++ b/README.markdown
@@ -157,6 +157,9 @@ Markdown document had newlines (by default, Markdown ignores these newlines).
 
 * `:link_attributes`: hash of extra attributes to add to links
 
+* `:autolink_with_nofollow`: add a `rel="nofollow"` attribute to all links
+generated with the `:autolink` option
+
 Example:
 
 ~~~~~ ruby

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -94,9 +94,18 @@ rndr_autolink(struct buf *ob, const struct buf *link, enum mkd_autolink type, vo
 	if (options->link_attributes) {
 		bufputc(ob, '\"');
 		options->link_attributes(ob, link, opaque);
+
+		if (options->flags & HTML_AUTOLINK_WITH_NOFOLLOW)
+		  BUFPUTSL(ob, "rel=\"nofollow\"");
+
 		bufputc(ob, '>');
 	} else {
-		BUFPUTSL(ob, "\">");
+		BUFPUTSL(ob, "\"");
+
+		if (options->flags & HTML_AUTOLINK_WITH_NOFOLLOW)
+		  BUFPUTSL(ob, "rel=\"nofollow\"");
+
+		BUFPUTSL(ob, ">");
 	}
 
 	/*

--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -50,6 +50,7 @@ typedef enum {
 	HTML_USE_XHTML = (1 << 8),
 	HTML_ESCAPE = (1 << 9),
 	HTML_PRETTIFY = (1 << 10),
+	HTML_AUTOLINK_WITH_NOFOLLOW = (1 << 11),
 } html_render_mode;
 
 typedef enum {

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -408,6 +408,10 @@ static VALUE rb_redcarpet_html_init(int argc, VALUE *argv, VALUE self)
 		if (rb_hash_aref(hash, CSTR2SYM("no_styles")) == Qtrue)
 			render_flags |= HTML_SKIP_STYLE;
 
+		/* autolink_with_nofollow */
+		if (rb_hash_aref(hash, CSTR2SYM("autolink_with_nofollow")) == Qtrue)
+			render_flags |= HTML_AUTOLINK_WITH_NOFOLLOW;
+
 		/* safelink */
 		if (rb_hash_aref(hash, CSTR2SYM("safe_links_only")) == Qtrue)
 			render_flags |= HTML_SAFELINK;

--- a/lib/redcarpet.rb
+++ b/lib/redcarpet.rb
@@ -68,12 +68,13 @@ class RedcarpetCompat
   def to_html(*_dummy)
     @markdown.render(@text)
   end
-  
+
   private
-  
+
   EXTENSION_MAP = {
     # old name => new name
     :autolink => :autolink,
+    :autolink_with_nofollow => :autolink_with_nofollow,
     :fenced_code => :fenced_code_blocks,
     :filter_html => :filter_html,
     :hard_wrap => :hard_wrap,
@@ -95,10 +96,11 @@ class RedcarpetCompat
     :smart => nil,
     :strict => nil
   }
-  
-  RENDERER_OPTIONS = [:filter_html, :no_images, :no_links, :no_styles, 
-    :safe_links_only, :with_toc_data, :hard_wrap, :prettify, :xhtml]
-  
+
+  RENDERER_OPTIONS = [:filter_html, :no_images, :no_links, :no_styles,
+    :safe_links_only, :with_toc_data, :hard_wrap, :prettify, :xhtml,
+    :autolink_with_nofollow]
+
   def rename_extensions(exts)
     exts.map do |old_name|
       if new_name = EXTENSION_MAP[old_name]
@@ -108,7 +110,7 @@ class RedcarpetCompat
       end
     end.compact
   end
-  
+
   # Returns two hashes, the extensions and renderer options
   # given the extension list
   def parse_extensions_and_renderer_options(exts)
@@ -116,7 +118,7 @@ class RedcarpetCompat
     exts.partition {|ext| !RENDERER_OPTIONS.include?(ext) }.
       map {|list| list_to_truthy_hash(list) }
   end
-  
+
   # Turns a list of symbols into a hash of <tt>symbol => true</tt>.
   def list_to_truthy_hash(list)
     list.inject({}) {|h, k| h[k] = true; h }

--- a/test/redcarpet_test.rb
+++ b/test/redcarpet_test.rb
@@ -96,6 +96,7 @@ class HTMLRenderTest < Test::Unit::TestCase
       :safe_links => Redcarpet::Render::HTML.new(:safe_links_only => true),
       :escape_html => Redcarpet::Render::HTML.new(:escape_html => true),
       :hard_wrap => Redcarpet::Render::HTML.new(:hard_wrap => true),
+      :autolink_with_nofollow => Redcarpet::Render::HTML.new(:autolink_with_nofollow => true),
     }
   end
 
@@ -173,6 +174,15 @@ EOE
 
     rd = render_with(@rndr[:escape_html], %([This'link"is](http://example.net/)))
     assert_equal "<p><a href=\"http://example.net/\">This&#39;link&quot;is</a></p>\n", rd
+  end
+
+  def test_that_nofollow_works
+    render = @rndr[:autolink_with_nofollow]
+    markdown = <<-MARKDOWN
+Hey, let's have a look at https://github.com/
+MARKDOWN
+    html = Redcarpet::Markdown.new(render, :autolink => true).render(markdown)
+    html_equal "<p>Hey, let's have a look at <a href=\"https://github.com/\" rel=\"nofollow\">https://github.com/</a></p>", html
   end
 end
 


### PR DESCRIPTION
The HTML renderer now has a `autolink_with_nofollow` option to make the autolink option a little bit more "SEO friendly". It simply adds a `rel="nofollow"` attribute to created links. All tests are green.

This pull request is a reference to #69

/cc @mattr- 
