### PR TITLE
Generalize gitignores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/lib/redcarpet.bundle
+*.so
+*.bundle
+*.o
 /tmp
 Gemfile.lock
-/lib/redcarpet.so


### PR DESCRIPTION
Allows for easier extension building inside a submodule.
