### PR TITLE
Ensure code spans put in emphasis work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Ensure nested code spans put in emphasis work correctly *Robin Dupret*
+
 ## Version 2.3.0
 
 * Add a `:disable_indented_code_blocks` option *Dmitriy Kiriyenko*

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -395,7 +395,7 @@ find_emph_char(uint8_t *data, size_t size, uint8_t c)
 	size_t i = 1;
 
 	while (i < size) {
-		while (i < size && data[i] != c && data[i] != '`' && data[i] != '[')
+		while (i < size && data[i] != c && data[i] != '[')
 			i++;
 
 		if (i == size)

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -89,4 +89,27 @@ EOE
     rd = render_with(@rndr[:escape_html], %([This'link"is](http://example.net/)))
     assert_equal "<p><a href=\"http://example.net/\">This&#39;link&quot;is</a></p>\n", rd
   end
+
+  def test_that_code_emphasis_work
+    markdown = <<-MD
+This should be **`a bold codespan`**
+However, this should be *`an emphasised codespan`*
+
+* **`ABC`** or **`DEF`**
+* Foo bar
+MD
+
+    html = <<HTML
+<p>This should be <strong><code>a bold codespan</code></strong>
+However, this should be <em><code>an emphasised codespan</code></em></p>
+
+<ul>
+<li><strong><code>ABC</code></strong> or <strong><code>DEF</code></strong></li>
+<li>Foo bar</li>
+</ul>
+HTML
+
+    output = render_with(Redcarpet::Render::HTML.new, markdown)
+    assert_equal html, output
+  end
 end


### PR DESCRIPTION
Hello,

When putting code span into simple or double emphasis, we've got an unexpected output. This commit fix this problem simply removing an ignore statement about back ticks in the `find_emph_char` function.

This pull request fixes #135 and #190.

All tests are green on my machine (with 2.0.0-p0) ; hope the Travis build will be too!

Have a nice day.
