### PR TITLE
Ensure nested parenthesis are handled into links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Ensure nested parenthesis are handled into links *Robin Dupret*
+
 * Ensure nested code spans put in emphasis work correctly *Robin Dupret*
 
 ## Version 2.3.0

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -898,10 +898,18 @@ char_link(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset
 		link_b = i;
 
 		/* looking for link end: ' " ) */
+		/* Count the number of open parenthesis */
+		size_t nb_p = 0;
+
 		while (i < size) {
 			if (data[i] == '\\') i += 2;
-			else if (data[i] == ')') break;
-			else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
+			else if (data[i] == '(' && i != 0) {
+				nb_p++; i++;
+			}
+			else if (data[i] == ')') {
+				if (nb_p == 0) break;
+				else nb_p--; i++;
+			} else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}
 

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -112,4 +112,12 @@ HTML
     output = render_with(Redcarpet::Render::HTML.new, markdown)
     assert_equal html, output
   end
+
+  def test_that_parenthesis_are_handled_into_links
+    markdown = "Hey have a look at the [bash man page](man:bash(1))!"
+    html = "<p>Hey have a look at the <a href=\"man:bash(1)\">bash man page</a>!</p>\n"
+    output = render_with(Redcarpet::Render::HTML.new, markdown)
+
+    assert_equal html, output
+  end
 end


### PR DESCRIPTION
Hello,

Make sure that parenthesis inside the link's url are correctly parsed Redcarpet considered the first ")" occurrence as the link's end so we first count the number of open "(" and decrement this number each time we found a ")".

This pull request should close issue #237.

Have a nice day.
