### PR TITLE
Apostrophe not detected while conversion into smarty html

### DIFF
--- a/test/smarty_html_test.rb
+++ b/test/smarty_html_test.rb
@@ -8,7 +8,7 @@ class SmartyHTMLTest < Test::Unit::TestCase
 
   def test_that_smartyhtml_converts_single_quotes
     markdown = @smarty_markdown.render("They're not for sale.")
-    assert_equal "<p>They&rsquo;re not for sale.</p>\n", markdown
+    assert_equal "<p>They&#39;re not for sale.</p>\n", markdown
   end
 
   def test_that_smartyhtml_converts_double_quotes


### PR DESCRIPTION
instead of right single quote &rsquo; it is taking apostrophe &#39;
