### PR TITLE
Fix FTP uris identified as emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Fix FTP uris identified as emails *Robin Dupret*
+
 * Add optional highlight support *Sam Soffes*
 
   This is `==highlighted==`.

--- a/ext/redcarpet/autolink.c
+++ b/ext/redcarpet/autolink.c
@@ -141,7 +141,7 @@ check_domain(uint8_t *data, size_t size, int allow_short)
 		return 0;
 
 	for (i = 1; i < size - 1; ++i) {
-		if (data[i] == '.') np++;
+		if (strchr(".:", data[i]) != NULL) np++;
 		else if (!isalnum(data[i]) && data[i] != '-') break;
 	}
 

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -120,4 +120,14 @@ HTML
 
     assert_equal html, output
   end
+
+  def test_autolinking_works_as_expected
+    markdown = "Example of uri ftp://user:pass@example.com/. Email foo@bar.com and link http://bar.com"
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, :autolink => true)
+    output = renderer.render(markdown)
+
+    assert output.include? '<a href="ftp://user:pass@example.com/">ftp://user:pass@example.com/</a>'
+    assert output.include? 'mailto:foo@bar.com'
+    assert output.include? '<a href="http://bar.com">'
+  end
 end


### PR DESCRIPTION
Hello,

This pull request ensures FTP uris are correctly parsed and not considered as an email address. This pull request should resolve #170.

Have a nice day.
