### PR TITLE
Lock some dependencies to avoid failures on Travis

### DIFF
--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -57,9 +57,9 @@ Gem::Specification.new do |s|
   s.executables = ["redcarpet"]
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "nokogiri"
-  s.add_development_dependency "rake-compiler"
-  s.add_development_dependency "test-unit"
-  s.add_development_dependency "bluecloth"
-  s.add_development_dependency "kramdown"
+  s.add_development_dependency "nokogiri", "~> 1.5.9"
+  s.add_development_dependency "rake-compiler", "~> 0.8.3"
+  s.add_development_dependency "test-unit", "~> 2.5.4"
+  s.add_development_dependency "bluecloth", "~> 2.2.0"
+  s.add_development_dependency "kramdown", "~> 1.0.2"
 end


### PR DESCRIPTION
Hi there,

Nokogiri 1.6 doesn't support Ruby 1.8.7 anymore, we should lock it to 1.5.9. Lock other development dependencies to prevent this kind of issues in the future.

Waiting answers in #266, I'm sending this patch to make Travis green.

Have a nice day.
