### PR TITLE
Make emphasis wrapped inside parenthesis parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Make emphasis wrapped inside parenthesis parsed *Robin Dupret*
+
 * Remove the Sundown submodule *Robin Dupret*
 
 * Fix FTP uris identified as emails *Robin Dupret*

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -603,7 +603,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 	size_t ret;
 
 	if (rndr->ext_flags & MKDEXT_NO_INTRA_EMPHASIS) {
-		if (offset > 0 && !_isspace(data[-1]) && data[-1] != '>')
+		if (offset > 0 && !_isspace(data[-1]) && data[-1] != '>' && data[-1] != '(')
 			return 0;
 	}
 

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -265,5 +265,9 @@ text
     assert render_with({:no_intra_emphasis => true}, "this fails: hello_world_") !~ /<em>/
     assert render_with({:no_intra_emphasis => true}, "this also fails: hello_world_#bye") !~ /<em>/
     assert render_with({:no_intra_emphasis => true}, "this works: hello_my_world") !~ /<em>/
+
+    markdown = "This is (**bold**) and this_is_not_italic!"
+    html = "<p>This is (<strong>bold</strong>) and this_is_not_italic!</p>\n"
+    assert_equal html, render_with({:no_intra_emphasis => true}, markdown)
   end
 end


### PR DESCRIPTION
Hello,

Previously, when an emphasis was put inside parenthesis, the option `no_intra_emphasis` return it as is. This commit fixes this issue. It is a redundant issue in tutorials or in readme files.

Should resolve #256.

Have a nice day.
