### PR TITLE
Add PHP-Markdown style footnotes support

### DIFF
--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -529,8 +529,12 @@ rndr_normal_text(struct buf *ob, const struct buf *text, void *opaque)
 static void
 rndr_footnotes(struct buf *ob, const struct buf *text, void *opaque)
 {
+	struct html_renderopt *options = opaque;
+	
 	if (ob->size) bufputc(ob, '\n');
-	BUFPUTSL(ob, "<div class=\"footnotes\">\n<hr>\n<ol>\n");
+	BUFPUTSL(ob, "<div class=\"footnotes\">\n");
+	BUFPUTSL(ob, USE_XHTML(options) ? "<hr/>\n" : "<hr>\n");
+	BUFPUTSL(ob, "<ol>\n");
 
 	if (text)
 		bufput(ob, text->data, text->size);


### PR DESCRIPTION
@djui opened an [identical pull request](https://github.com/vmg/redcarpet/pull/241) a month ago, but it has stalled. Thought I would submit my own with the requested changes.

This includes the great original work by @bdolman and @adamflorin, a fix to footnote parsing by @microjo, a test case in `test/html_render_test.rb`, and edits to the changelog and readme.
