### PR TITLE
Avoid escaping on HTML comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Avoid escaping for HTML comments *Robin Dupret*
+
 * Make emphasis wrapped inside parenthesis parsed *Robin Dupret*
 
 * Remove the Sundown submodule *Robin Dupret*

--- a/ext/redcarpet/houdini_html_e.c
+++ b/ext/redcarpet/houdini_html_e.c
@@ -69,7 +69,11 @@ houdini_escape_html0(struct buf *ob, const uint8_t *src, size_t size, int secure
 		if (src[i] == '/' && !secure) {
 			bufputc(ob, '/');
 		} else {
-			bufputs(ob, HTML_ESCAPES[esc]);
+			/* The left and right tags (< and >) aren't escaped in comments */
+			if ((src[i] == '<' && src[i + 1] == '!') || (src[i] == '>' && src[i - 1] == '-'))
+				bufputc(ob, src[i]);
+			else
+				bufputs(ob, HTML_ESCAPES[esc]);
 		}
 
 		i++;

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -130,4 +130,10 @@ HTML
     assert output.include? 'mailto:foo@bar.com'
     assert output.include? '<a href="http://bar.com">'
   end
+
+  def test_that_comments_arent_escaped
+    input = "<!-- This is a nice comment! -->"
+    output = render_with(@rndr[:escape_html], input)
+    assert output.include? input
+  end
 end


### PR DESCRIPTION
Hello,

HTML comments opening and closing tags were previously escaped. This wasn't intended. This pull request fix this behavior.

Should resolve #268
