### PR TITLE
Allow to pass a nesting_level option for HTML_TOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+* Allow to set a maximum rendering level for HTML_TOC
+
+  Allow the user to pass a `nesting_level` option when instantiating a
+  new HTML_TOC render object in order to limit the nesting level in the
+  generated table of content. For example:
+
+  ~~~ruby
+  Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC.new(nesting_level: 2))
+  ~~~
+
+  *Robin Dupret*
+
 ## Version 3.0.0
 
 * Remove support for Ruby 1.8.x *Matt Rogers & Robin Dupret*

--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -30,6 +30,7 @@ struct html_renderopt {
 		int header_count;
 		int current_level;
 		int level_offset;
+		int nesting_level;
 	} toc_data;
 
 	unsigned int flags;
@@ -65,7 +66,7 @@ extern void
 sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options_ptr, unsigned int render_flags);
 
 extern void
-sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options_ptr);
+sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options_ptr, int nesting_level);
 
 extern void
 sdhtml_smartypants(struct buf *ob, const uint8_t *text, size_t size);

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -439,12 +439,26 @@ static VALUE rb_redcarpet_html_init(int argc, VALUE *argv, VALUE self)
 	return Qnil;
 }
 
-static VALUE rb_redcarpet_htmltoc_init(VALUE self)
+static VALUE rb_redcarpet_htmltoc_init(int argc, VALUE *argv, VALUE self)
 {
 	struct rb_redcarpet_rndr *rndr;
+	int nesting_level = 6;
+	VALUE hash, key = Qnil;
+
 	Data_Get_Struct(self, struct rb_redcarpet_rndr, rndr);
 
-	sdhtml_toc_renderer(&rndr->callbacks, (struct html_renderopt *)&rndr->options.html);
+	if (rb_scan_args(argc, argv, "01", &hash) == 1) {
+		Check_Type(hash, T_HASH);
+
+		key = CSTR2SYM("nesting_level");
+
+		if (RTEST(rb_hash_aref(hash, key))) {
+			Check_Type(rb_hash_aref(hash, key), T_FIXNUM);
+			nesting_level = NUM2INT(rb_hash_aref(hash, key));
+		}
+	}
+
+	sdhtml_toc_renderer(&rndr->callbacks, (struct html_renderopt *)&rndr->options.html, nesting_level);
 	rb_redcarpet__overload(self, rb_cRenderHTML_TOC);
 
 	return Qnil;
@@ -478,7 +492,7 @@ void Init_redcarpet_rndr()
 	rb_define_method(rb_cRenderHTML, "initialize", rb_redcarpet_html_init, -1);
 
 	rb_cRenderHTML_TOC = rb_define_class_under(rb_mRender, "HTML_TOC", rb_cRenderBase);
-	rb_define_method(rb_cRenderHTML_TOC, "initialize", rb_redcarpet_htmltoc_init, 0);
+	rb_define_method(rb_cRenderHTML_TOC, "initialize", rb_redcarpet_htmltoc_init, -1);
 
 	rb_mSmartyPants = rb_define_module_under(rb_mRender, "SmartyPants");
 	rb_define_method(rb_mSmartyPants, "postprocess", rb_redcarpet_smartypants_render, 1);

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
     test/test_helper.rb
     test/custom_render_test.rb
     test/html_render_test.rb
+    test/html_toc_render_test.rb
     test/markdown_test.rb
     test/pathological_inputs_test.rb
     test/redcarpet_compat_test.rb

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -4,18 +4,28 @@ require 'test_helper'
 class HTMLTOCRenderTest < Test::Unit::TestCase
   def setup
     @render = Redcarpet::Render::HTML_TOC
+    @markdown = "# A title \n## A subtitle\n## Another one \n### A sub-sub-title"
   end
 
   def test_simple_toc_render
-    markdown = "# A title \n## A subtitle\n## Another on \n### A sub-sub-title"
-
     renderer = Redcarpet::Markdown.new(@render)
-    output = renderer.render(markdown).strip
+    output = renderer.render(@markdown).strip
 
     assert output.start_with?("<ul>")
     assert output.end_with?("</ul>")
 
     assert_equal 4, output.split("<ul>").length
     assert_equal 5, output.split("<li>").length
+  end
+
+  def test_granular_toc_render
+    renderer = Redcarpet::Markdown.new(@render.new(nesting_level: 2))
+    output = renderer.render(@markdown).strip
+
+    assert output.start_with?("<ul>")
+    assert output.end_with?("</ul>")
+
+    assert_equal 4, output.split("<li>").length
+    assert !output.include?("A sub-sub title")
   end
 end


### PR DESCRIPTION
Hello,

This pull request allows the user to pass a `max_level` option when instantiating a new `HTML_TOC` render object in order to limit the nesting level in the generated table of content. For example:

``` ruby
Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC.new(nesting_level: 2))
```

Resolve #267

Moreover, I've added some tests since there weren't any test related to this render. Please tell me if I'm doing it the right way ; I'm not sure about the assertions.

Have a nice day.
