### PR TITLE
Remove Sundown and Upskirt remains

### DIFF
--- a/ext/redcarpet/autolink.h
+++ b/ext/redcarpet/autolink.h
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef UPSKIRT_AUTOLINK_H
-#define UPSKIRT_AUTOLINK_H
+#ifndef AUTOLINK_H__
+#define AUTOLINK_H__
 
 #include "buffer.h"
 

--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef UPSKIRT_HTML_H
-#define UPSKIRT_HTML_H
+#ifndef HTML_H__
+#define HTML_H__
 
 #include "markdown.h"
 #include "buffer.h"

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2845,11 +2845,3 @@ sd_markdown_free(struct sd_markdown *md)
 
 	free(md);
 }
-
-void
-sd_version(int *ver_major, int *ver_minor, int *ver_revision)
-{
-	*ver_major = SUNDOWN_VER_MAJOR;
-	*ver_minor = SUNDOWN_VER_MINOR;
-	*ver_revision = SUNDOWN_VER_REVISION;
-}

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -16,8 +16,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef UPSKIRT_MARKDOWN_H
-#define UPSKIRT_MARKDOWN_H
+#ifndef MARKDOWN_H__
+#define MARKDOWN_H__
 
 #include "buffer.h"
 #include "autolink.h"
@@ -25,11 +25,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#define SUNDOWN_VERSION "1.16.0"
-#define SUNDOWN_VER_MAJOR 1
-#define SUNDOWN_VER_MINOR 16
-#define SUNDOWN_VER_REVISION 0
 
 /********************
  * TYPE DEFINITIONS *
@@ -133,9 +128,6 @@ sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, str
 
 extern void
 sd_markdown_free(struct sd_markdown *md);
-
-extern void
-sd_version(int *major, int *minor, int *revision);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello,

Not a very useful pull request but it removes the pre-processor directives about Upskirt and Sundown. The functions
prefixed with "sd_" remain the same not to destroy the blame view on files. I'm annoyed to see this legacy code. :smile: 

Have a nice day.
