### PR TITLE
Add no_underscore_emphasis option.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -112,6 +112,9 @@ like a reference-style link: it consists of a  marker next to the text (e.g.
 `This is a sentence.[^1]`) and a footnote definition on its own line anywhere
 within the document (e.g. `[^1]: This is a footnote.`).
 
+* `:no_underscore_emphasis`: do not parse underscore as emphasis.
+`This is _rendered_as_is_`.
+
 Example:
 
 ~~~~~ ruby

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2698,7 +2698,8 @@ sd_markdown_new(
 
 	if (md->cb.emphasis || md->cb.double_emphasis || md->cb.triple_emphasis) {
 		md->active_char['*'] = MD_CHAR_EMPHASIS;
-		md->active_char['_'] = MD_CHAR_EMPHASIS;
+		if (! (extensions & MKDEXT_NO_UNDERSCORE_EMPHASIS))
+			md->active_char['_'] = MD_CHAR_EMPHASIS;
 		if (extensions & MKDEXT_STRIKETHROUGH)
 			md->active_char['~'] = MD_CHAR_EMPHASIS;
 		if (extensions & MKDEXT_HIGHLIGHT)

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -57,7 +57,8 @@ enum mkd_extensions {
 	MKDEXT_LAX_SPACING = (1 << 8),
 	MKDEXT_DISABLE_INDENTED_CODE = (1 << 9),
 	MKDEXT_HIGHLIGHT = (1 << 10),
-	MKDEXT_FOOTNOTES = (1 << 11)
+	MKDEXT_FOOTNOTES = (1 << 11),
+	MKDEXT_NO_UNDERSCORE_EMPHASIS = (1 << 12)
 };
 
 /* sd_callbacks - functions for rendering parsed data */

--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -53,6 +53,9 @@ static void rb_redcarpet_md_flags(VALUE hash, unsigned int *enabled_extensions_p
 	if (rb_hash_lookup(hash, CSTR2SYM("highlight")) == Qtrue)
 		extensions |= MKDEXT_HIGHLIGHT;
 
+	if (rb_hash_lookup(hash, CSTR2SYM("no_underscore_emphasis")) == Qtrue)
+		extensions |= MKDEXT_NO_UNDERSCORE_EMPHASIS;
+
 	if (rb_hash_lookup(hash, CSTR2SYM("lax_spacing")) == Qtrue)
 		extensions |= MKDEXT_LAX_SPACING;
 

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -189,4 +189,54 @@ HTML
     output = renderer.render(markdown)
     assert_equal html, output
   end
+
+  def test_no_underscore_emphasis_enabled_asterisk
+    markdown = <<-MD
+This should be **`a bold codespan`**
+However, this should be *`an emphasised codespan`*
+
+* **`ABC`** or **`DEF`**
+* Foo bar
+MD
+
+    html = <<HTML
+<p>This should be <strong><code>a bold codespan</code></strong>
+However, this should be <em><code>an emphasised codespan</code></em></p>
+
+<ul>
+<li><strong><code>ABC</code></strong> or <strong><code>DEF</code></strong></li>
+<li>Foo bar</li>
+</ul>
+HTML
+
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, :no_underscore_emphasis => true)
+    output = renderer.render(markdown)
+    assert_equal html, output
+  end
+
+  def test_no_underscore_emphasis_enabled_underscore
+    markdown = <<-MD
+This should be __`a codespan`__
+Also, this should be _`a codespan`_
+
+* __`ABC`__ or __`DEF`__
+* Foo bar
+* Foo_bar_
+MD
+
+    html = <<HTML
+<p>This should be __<code>a codespan</code>__
+Also, this should be _<code>a codespan</code>_</p>
+
+<ul>
+<li>__<code>ABC</code>__ or __<code>DEF</code>__</li>
+<li>Foo bar</li>
+<li>Foo_bar_</li>
+</ul>
+HTML
+
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, :no_underscore_emphasis => true)
+    output = renderer.render(markdown)
+    assert_equal html, output
+  end
 end


### PR DESCRIPTION
In some usecases, I don't want to parse underscore as a special character.
This commit add an option for it.
