### PR TITLE
Autolink short domains

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -930,7 +930,7 @@ char_autolink_url(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_
 
 	link = rndr_newbuf(rndr, BUFFER_SPAN);
 
-	if ((link_len = sd_autolink__url(&rewind, link, data, offset, size, 0)) > 0) {
+	if ((link_len = sd_autolink__url(&rewind, link, data, offset, size, SD_AUTOLINK_SHORT_DOMAINS)) > 0) {
 		ob->size -= rewind;
 		rndr->cb.autolink(ob, link, MKDA_NORMAL, rndr->opaque);
 	}

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -189,4 +189,14 @@ HTML
     output = renderer.render(markdown)
     assert_equal html, output
   end
+  
+  def test_autolink_short_domains
+    markdown = "Example of uri ftp://auto/short/domains. Email auto@l.n and link http://a/u/t/o/s/h/o/r/t"
+    renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, :autolink => true)
+    output = renderer.render(markdown)
+
+    assert output.include? '<a href="ftp://auto/short/domains">ftp://auto/short/domains</a>'
+    assert output.include? 'mailto:auto@l.n'
+    assert output.include? '<a href="http://a/u/t/o/s/h/o/r/t">http://a/u/t/o/s/h/o/r/t</a>'
+  end
 end


### PR DESCRIPTION
In some usecases, I want to autolink even if they were very short domains.
This commit add an option for it.
