### PR TITLE
Contributing: Add steps needed to configure environment before running unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,31 @@
 
 1. [Fork the repository.][fork]
 2. [Create a topic branch.][branch]
-3. Write a failing test to capture existing bug or lack of feature.
-4. Run `rake test` to verify that test fails.
-5. Implement your feature or bug fix.
-6. Ensure tests pass.
-7. If it's a new feature or a bug fix, please add an entry to the changelog file.
-8. Add, commit, and push your changes.
-9. [Submit a pull request.][pr]
+3. Check which version of Ruby is installed on your machine with `ruby -v`.
+   The list of supported Ruby versions is listed in [.travis.yml][travis_yml].
+   Set up one of these versions; use of [RVM][rvm] is recommended to switch
+   easily between different versions.
+4. [Install bundler.][bundler]
+5. Check that unit tests pass with `rake test`.
+6. Write a failing test to capture existing bug or lack of feature.
+7. Run `rake test` to verify that test fails.
+8. Implement your feature or bug fix.
+9. Ensure tests pass.
+10. If it's a new feature or a bug fix,
+    please add an entry to the changelog file.
+11. Add, commit, and push your changes.
+12. [Submit a pull request.][pr]
+13. You will get some feedback and may need to push additional commits
+    with more fixes to the same branch; this will update your pull request
+    automatically.
+14. [Squash your commits into a single one][rebase]
+    and [force a push to the same branch][force_push].
 
+[branch]: http://git-scm.com/book/en/Git-Branching-Branching-Workflows#Topic-Branches
+[bundler]: http://bundler.io
+[force_push]: https://help.github.com/articles/dealing-with-non-fast-forward-errors
 [fork]: https://help.github.com/articles/fork-a-repo
-[branch]: http://learn.github.com/p/branching.html
 [pr]: https://help.github.com/articles/using-pull-requests
+[rebase]: https://help.github.com/articles/interactive-rebase
+[rvm]: https://rvm.io
+[travis_yml]: https://github.com/vmg/redcarpet/blob/master/.travis.yml


### PR DESCRIPTION
It took me some time to figure out how to get a properly running environment.
I first had to understand what I needed (e.g. bundler, openssl support)
and then a simple way to install it.

The first issue that I encountered after installing bundler:
http://www.beginnerruby.com/rails-troubleshooting/fixing-opensslbundler-issue-for-rails-on-debian/

And then I had to reinstall ruby... I decided to go with the RVM approach,
which was simple enough as the installation provided feedback at different
steps to indicate how to remove conflicting packages previously installed
in Ubuntu and avoid potential errors.

There may be a need for an additional step to enable openssl support in ruby:
I did not run either `rvm pkg install openssl` before installing ruby with
rvm, neither did I provide the parameter --with-opensll-dir when installing
ruby with rvm `rvm install 1.9.3 --with-opensll-dir=$HOME/.rvm/usr` but I
assume that this was taken care of either by running `rvm install 1.9.3` or
`rvm requirements` which I have not included in these steps because it looked
from the console output like it was run by `rvm install 1.9.3` anyway.
