### PR TITLE
Add rule to ignore temporary vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-*.so
 *.bundle
 *.o
+*.so
+*.swp
 /ext/redcarpet/Makefile
 /tmp
 Gemfile.lock


### PR DESCRIPTION
I also reordered the wildcard rules in alphabetical order of extension.

The rationale is to avoid submitting by mistake one of the temporary files created by vim when editing a file.
