### PR TITLE
Cleanup in the code

### DIFF
--- a/ext/redcarpet/buffer.c
+++ b/ext/redcarpet/buffer.c
@@ -120,7 +120,7 @@ bufprintf(struct buf *buf, const char *fmt, ...)
 
 	if (buf->size >= buf->asize && bufgrow(buf, buf->size + 1) < 0)
 		return;
-	
+
 	va_start(ap, fmt);
 	n = _buf_vsnprintf((char *)buf->data + buf->size, buf->asize - buf->size, fmt, ap);
 	va_end(ap);
@@ -194,32 +194,3 @@ bufrelease(struct buf *buf)
 	free(buf->data);
 	free(buf);
 }
-
-
-/* bufreset: frees internal data of the buffer */
-void
-bufreset(struct buf *buf)
-{
-	if (!buf)
-		return;
-
-	free(buf->data);
-	buf->data = NULL;
-	buf->size = buf->asize = 0;
-}
-
-/* bufslurp: removes a given number of bytes from the head of the array */
-void
-bufslurp(struct buf *buf, size_t len)
-{
-	assert(buf && buf->unit);
-
-	if (len >= buf->size) {
-		buf->size = 0;
-		return;
-	}
-
-	buf->size -= len;
-	memmove(buf->data, buf->data + len, buf->size);
-}
-

--- a/ext/redcarpet/buffer.h
+++ b/ext/redcarpet/buffer.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2008, Natacha Porté
  * Copyright (c) 2011, Vicent Martí
  *
@@ -71,12 +71,6 @@ void bufputc(struct buf *, int);
 
 /* bufrelease: decrease the reference count and free the buffer if needed */
 void bufrelease(struct buf *);
-
-/* bufreset: frees internal data of the buffer */
-void bufreset(struct buf *);
-
-/* bufslurp: removes a given number of bytes from the head of the array */
-void bufslurp(struct buf *, size_t);
 
 /* bufprintf: formatted printing to a buffer */
 void bufprintf(struct buf *, const char *, ...) __attribute__ ((format (printf, 2, 3)));

--- a/ext/redcarpet/houdini.h
+++ b/ext/redcarpet/houdini.h
@@ -20,15 +20,7 @@ extern "C" {
 
 extern void houdini_escape_html(struct buf *ob, const uint8_t *src, size_t size);
 extern void houdini_escape_html0(struct buf *ob, const uint8_t *src, size_t size, int secure);
-extern void houdini_unescape_html(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_escape_xml(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_escape_uri(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_escape_url(struct buf *ob, const uint8_t *src, size_t size);
 extern void houdini_escape_href(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_unescape_uri(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_unescape_url(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_escape_js(struct buf *ob, const uint8_t *src, size_t size);
-extern void houdini_unescape_js(struct buf *ob, const uint8_t *src, size_t size);
 
 #ifdef __cplusplus
 }

--- a/ext/redcarpet/stack.c
+++ b/ext/redcarpet/stack.c
@@ -51,15 +51,6 @@ redcarpet_stack_init(struct stack *st, size_t initial_size)
 	return redcarpet_stack_grow(st, initial_size);
 }
 
-void *
-redcarpet_stack_pop(struct stack *st)
-{
-	if (!st->size)
-		return NULL;
-
-	return st->item[--st->size];
-}
-
 int
 redcarpet_stack_push(struct stack *st, void *item)
 {
@@ -69,13 +60,3 @@ redcarpet_stack_push(struct stack *st, void *item)
 	st->item[st->size++] = item;
 	return 0;
 }
-
-void *
-redcarpet_stack_top(struct stack *st)
-{
-	if (!st->size)
-		return NULL;
-
-	return st->item[st->size - 1];
-}
-

--- a/ext/redcarpet/stack.h
+++ b/ext/redcarpet/stack.h
@@ -19,9 +19,6 @@ int redcarpet_stack_init(struct stack *, size_t);
 
 int redcarpet_stack_push(struct stack *, void *);
 
-void *redcarpet_stack_pop(struct stack *);
-void *redcarpet_stack_top(struct stack *);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Hello,

This pull request falls in a "cosmetic" change but it removes extra headers and functions from the code to have cleaner files since some of them are a bit messy. :smiley: 

@vmg : I would love to be sure that these snippets are really useless. The tests are passing on my machine though. Let me know if we should not remove some of them. Thank you! Blames all point to 27616ac53414cd04ccc2455ce7022b6ff0774d33 so I'm not sure about the removal of these pieces.

Have a nice day.
