### PR TITLE
Ensure GitHub style anchors are also in TOC

### DIFF
--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -27,7 +27,6 @@ extern "C" {
 
 struct html_renderopt {
 	struct {
-		int header_count;
 		int current_level;
 		int level_offset;
 		int nesting_level;

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -28,4 +28,14 @@ class HTMLTOCRenderTest < Test::Unit::TestCase
     assert_equal 4, output.split("<li>").length
     assert !output.include?("A sub-sub title")
   end
+
+  def test_toc_heading_id
+    renderer = Redcarpet::Markdown.new(@render)
+    output = renderer.render(@markdown)
+
+    assert_match /a-title/, output
+    assert_match /a-subtitle/, output
+    assert_match /another-one/, output
+    assert_match /a-sub-sub-title/, output
+  end
 end


### PR DESCRIPTION
Hi,

Pull request #186 introduced GitHub style anchors but we forgot also to generate these nice IDs in the tables of content.

Simply move the snippets about IDs generation to a function to avoid code duplication and make output common if we need to output it elsewhere.

Also remove the useless `header_count` entry from the `toc_data` struct since we are not generating header's IDs through a counter.

I haven't add any changelog entry since this is kinda continuation of the original pull request.

Have a nice day.
