### PR TITLE
Avoid installation of useless gems on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install tidy
 
+install: bundle install --without=benchmark
+
 rvm:
   - 1.9.2
   - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,8 @@
 source "https://rubygems.org/"
+
 gemspec
+
+group :benchmark do
+  gem "bluecloth", "~> 2.2.0"
+  gem "kramdown", "~> 1.0.2"
+end

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -62,6 +62,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "nokogiri", "~> 1.6.0"
   s.add_development_dependency "rake-compiler", "~> 0.8.3"
   s.add_development_dependency "test-unit", "~> 2.5.4"
-  s.add_development_dependency "bluecloth", "~> 2.2.0"
-  s.add_development_dependency "kramdown", "~> 1.0.2"
 end


### PR DESCRIPTION
Hello,

BlueCloth and kramdown are only necessary in case we want to do some benchmarking. Let's avoid installation of those gems on Travis to decrease build time.

Have a nice day.
