### PR TITLE
Run CI against ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ rvm:
   - 1.9.3
   - 2.0.0
   - rbx-19mode
+  - ruby-head
 
 notifications:
   email: false
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
Hi,

I've added `ruby-head` to the list of tested versions to get a better feedback on errors and be more or less ready for 2.1 for the next release of Redcarpet.

I don't think that this one needs a changelog entry but let me know if I should add it.

Have a nice day.
