### PR TITLE
Revert the unescaping behavior on comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* Revert the unescaping behavior on comments
+
+  This behavior doesn't follow the conformance suite.
+
+  *Robin Dupret*
+
 * Update the conformance test suite to provide better feedback to CI
   systems.
 

--- a/ext/redcarpet/houdini_html_e.c
+++ b/ext/redcarpet/houdini_html_e.c
@@ -66,15 +66,10 @@ houdini_escape_html0(struct buf *ob, const uint8_t *src, size_t size, int secure
 			break;
 
 		/* The forward slash is only escaped in secure mode */
-		if (src[i] == '/' && !secure) {
+		if (src[i] == '/' && !secure)
 			bufputc(ob, '/');
-		} else {
-			/* The left and right tags (< and >) aren't escaped in comments */
-			if ((src[i] == '<' && src[i + 1] == '!') || (src[i] == '>' && src[i - 1] == '-'))
-				bufputc(ob, src[i]);
-			else
-				bufputs(ob, HTML_ESCAPES[esc]);
-		}
+		else
+			bufputs(ob, HTML_ESCAPES[esc]);
 
 		i++;
 	}

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -132,12 +132,6 @@ HTML
     assert output.include? '<a href="http://bar.com">'
   end
 
-  def test_that_comments_arent_escaped
-    input = "<!-- This is a nice comment! -->"
-    output = render_with(@rndr[:escape_html], input)
-    assert output.include? input
-  end
-
   def test_that_footnotes_work
     markdown = <<-MD
 This is a footnote.[^1]


### PR DESCRIPTION
Hello,

In #272 we introduced unescaping on HTML comments but at that time, we didn't really care about the conformance suite. I think that we should simply revert this behaviour ; maybe provide it through an option for the HTML render but I'm afraid that the number of options grow over the time if we wan't to allow customization of such things.

I would love to have your thoughts @mattr-. :smile: 

Thanks, have a nice day.
