### PR TITLE
Ensure inline markup in titles is correctly stripped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+* Ensure inline markup in titles is correctly stripped when generating
+  headers' anchor.
+
+  *Robin Dupret*
+
 * Revert the unescaping behavior on comments
 
   This behavior doesn't follow the conformance suite.

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -255,8 +255,11 @@ rndr_linebreak(struct buf *ob, void *opaque)
 char *header_id(const struct buf *text)
 {
 	VALUE str = rb_str_new2(bufcstr(text));
-	VALUE regex = rb_reg_new(" +", 2 /* length */, 0);
-	VALUE heading = rb_funcall(str, rb_intern("gsub"), 2, regex, rb_str_new2("-"));
+	VALUE space_regex = rb_reg_new(" +", 2 /* length */, 0);
+	VALUE tags_regex = rb_reg_new("<\\/?[^>]*>", 10, 0);
+
+	VALUE heading = rb_funcall(str, rb_intern("gsub"), 2, space_regex, rb_str_new2("-"));
+	heading = rb_funcall(heading, rb_intern("gsub"), 2, tags_regex, rb_str_new2(""));
 	heading = rb_funcall(heading, rb_intern("downcase"), 0);
 
 	return StringValueCStr(heading);

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class HTMLTOCRenderTest < Test::Unit::TestCase
   def setup
     @render = Redcarpet::Render::HTML_TOC
-    @markdown = "# A title \n## A subtitle\n## Another one \n### A sub-sub-title"
+    @markdown = "# A title \n## A __nice__ subtitle\n## Another one \n### A sub-sub-title"
   end
 
   def test_simple_toc_render
@@ -34,7 +34,7 @@ class HTMLTOCRenderTest < Test::Unit::TestCase
     output = renderer.render(@markdown)
 
     assert_match /a-title/, output
-    assert_match /a-subtitle/, output
+    assert_match /a-nice-subtitle/, output
     assert_match /another-one/, output
     assert_match /a-sub-sub-title/, output
   end


### PR DESCRIPTION
Hello,

This pull request ensure there is no inline markup such as `strong` or `em` tags in the headers' anchors. Actually, we could reduce computation time with the stripped version of the text but I think that it would be hard since the function is called _via_ callbacks so user won't have the markup overriding the default ones. Moreover, I've written [a tiny benchmark](https://gist.github.com/robin850/6251839) in pure Ruby but it seems that it was previously faster ; however if the regex is applied on a string without any tags, there is no differences:

|  | user | system | total | real |
| --- | --- | --- | --- | --- |
| Original | 0.430000 | 0.020000 | 0.450000 | (  0.595127) |
| New | 0.890000 | 0.000000 | 0.890000 | (  0.915451) |

**Note** : Please don't delete the branch of this PR ; I have still some other issues to fix. Thank you! :smiley: 

Have a nice day.
