### PR TITLE
Disable allowed failures on ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,3 @@ rvm:
 notifications:
   email: false
 
-matrix:
-  allow_failures:
-    - rvm: ruby-head


### PR DESCRIPTION
Hello,

Now that Bundler can be triggered on Travis I think that we could consider that we are ready for Ruby 2.1, what do you think ? :smiley: 

Have a nice day.
