### PR TITLE
Make ordered lists preceded by paragraph parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+* Make ordered lists preceded by paragraph parsed with `:lax_spacing`
+
+  Previously, enabling the `:lax_spacing` option, if a paragraph was
+  followed by an ordered list it was previously unparsed and was part
+  of the paragraph but this is no more the case.
+
+  *Robin Dupret*
+
 * Feed the gemspec into ExtensionTask so that we can pre-compile.
   ie. `rake native gem`
 

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -793,7 +793,7 @@ char_codespan(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 /* char_quote • '"' parsing a quote */
 static size_t
 char_quote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
-{    
+{
 	size_t end, nq = 0, i, f_begin, f_end;
 
 	/* counting the number of quotes in the delimiter */
@@ -1644,7 +1644,7 @@ parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 		 * let's check to see if there's some kind of block starting
 		 * here
 		 */
-		if ((rndr->ext_flags & MKDEXT_LAX_SPACING) && !isalnum(data[i])) {
+		if ((rndr->ext_flags & MKDEXT_LAX_SPACING) && !isalpha(data[i])) {
 			if (prefix_oli(data + i, size - i) ||
 				prefix_uli(data + i, size - i)) {
 				end = i;

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -274,4 +274,12 @@ text
     html = "<p>This is (<strong>bold</strong>) and this_is_not_italic!</p>\n"
     assert_equal html, render_with({:no_intra_emphasis => true}, markdown)
   end
+
+  def test_ordered_lists_with_lax_spacing
+    markdown = "Foo:\n1. Foo\n2. Bar"
+    output = render_with({lax_spacing: true}, markdown)
+
+    assert_match /<ol>/, output
+    assert_match /<li>Foo<\/li>/, output
+  end
 end


### PR DESCRIPTION
Hello,

Previously, enabling the `:lax_spacing` option, if a paragraph was followed by an ordered list it was previously unparsed and was part of the paragraph but this is no more the case.

The fix is pretty straightforward, since the `parse_paragraph` method was checking through the `isalnum` function whether the first char on the next line was alpha-numeric but ordered list start with numerics, we just need to substitute the function with isalpha.

Fixes #311

Have a nice day.
