### PR TITLE
Add --pygments command line option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* Add a --pygments command line option
+
+  Make it possible to enable syntax highlighting via the command line.
+
+  *Ana Nelson*
+
 * Make ordered lists preceded by paragraph parsed with `:lax_spacing`
 
   Previously, enabling the `:lax_spacing` option, if a paragraph was

--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -23,6 +23,23 @@ $:.unshift File.expand_path('lib', root)
 
 render_extensions = {}
 parse_extensions = {}
+
+# Custom renderers
+begin
+  require 'pygments'
+  class HTMLwithPygments < Redcarpet::Render::HTML
+    def block_code(code, language)
+      Pygments.highlight(code, :lexer => language)
+    end
+  end
+  pygments_available = true
+rescue LoadError
+  class HTMLwithPygments < Redcarpet::Render::HTML
+  end
+  pygments_available = false
+end
+
+# Default renderer
 renderer = Redcarpet::Render::HTML
 
 ARGV.delete_if do |arg|
@@ -34,6 +51,13 @@ ARGV.delete_if do |arg|
     parse_extensions[arg.to_sym] = true
   elsif arg == '--smarty'
     renderer = Redcarpet::Render::SmartyHTML
+  elsif arg == '--pygments'
+    if pygments_available
+      renderer = HTMLwithPygments
+    else
+      puts "Pygments.rb must be installed."
+      sys.exit(1)
+    end
   else
     false
   end

--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -4,7 +4,7 @@
 # no <file> or when <file> is '-', read Markdown source text from standard input.
 # With <extension>s, perform additional Markdown processing before writing output.
 # With --smarty, use the SmartyHTML renderer
-# With --pygments, use the HTMLwithPygments renderer (Pygments.rb must be installed and in your bundle)
+# With --pygments, use the HTMLwithPygments renderer (Pygments.rb must be installed)
 if ARGV.include?('--help') or ARGV.include?('-h')
   File.read(__FILE__).split("\n").grep(/^# /).each do |line|
     puts line[2..-1]

--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -4,7 +4,7 @@
 # no <file> or when <file> is '-', read Markdown source text from standard input.
 # With <extension>s, perform additional Markdown processing before writing output.
 # With --smarty, use the SmartyHTML renderer
-# With --pygments, use the HTMLwithPygments renderer (Pygments.rb must be installed)
+# With --pygments, use the HTMLwithPygments renderer (Pygments.rb must be installed and in your bundle)
 if ARGV.include?('--help') or ARGV.include?('-h')
   File.read(__FILE__).split("\n").grep(/^# /).each do |line|
     puts line[2..-1]

--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
-# Usage: redcarpet [--parse-<extension>...] [--render-<extension>...] [--smarty] [<file>...]
+# Usage: redcarpet [--parse-<extension>...] [--render-<extension>...] [--pygments] [--smarty] [<file>...]
 # Convert one or more Markdown files to HTML and write to standard output. With
 # no <file> or when <file> is '-', read Markdown source text from standard input.
 # With <extension>s, perform additional Markdown processing before writing output.
 # With --smarty, use the SmartyHTML renderer
+# With --pygments, use the HTMLwithPygments renderer (Pygments.rb must be installed)
 if ARGV.include?('--help') or ARGV.include?('-h')
   File.read(__FILE__).split("\n").grep(/^# /).each do |line|
     puts line[2..-1]
@@ -12,6 +13,7 @@ if ARGV.include?('--help') or ARGV.include?('-h')
 end
 
 require 'redcarpet'
+require 'redcarpet/render_html_with_pygments'
 
 if ARGV.include?('--version') or ARGV.include?('-v')
   puts "Redcarpet #{Redcarpet::VERSION}"
@@ -24,21 +26,6 @@ $:.unshift File.expand_path('lib', root)
 render_extensions = {}
 parse_extensions = {}
 
-# Custom renderers
-begin
-  require 'pygments'
-  class HTMLwithPygments < Redcarpet::Render::HTML
-    def block_code(code, language)
-      Pygments.highlight(code, :lexer => language)
-    end
-  end
-  pygments_available = true
-rescue LoadError
-  class HTMLwithPygments < Redcarpet::Render::HTML
-  end
-  pygments_available = false
-end
-
 # Default renderer
 renderer = Redcarpet::Render::HTML
 
@@ -49,14 +36,15 @@ ARGV.delete_if do |arg|
   elsif arg =~ /^--parse-([\w-]+)$/
     arg = $1.gsub('-', '_')
     parse_extensions[arg.to_sym] = true
-  elsif arg == '--smarty'
-    renderer = Redcarpet::Render::SmartyHTML
-  elsif arg == '--pygments'
-    if pygments_available
-      renderer = HTMLwithPygments
+  elsif arg =~ /^--([\w-]+)$/
+    arg = $1.gsub('-', '_')
+    case arg
+    when "smarty"
+        renderer = Redcarpet::Render::SmartyHTML
+    when "pygments"
+        renderer = Redcarpet::Render::HTMLwithPygments
     else
-      puts "Pygments.rb must be installed."
-      sys.exit(1)
+        raise "Unsupported renderer or invalid option '--#{arg}'"
     end
   else
     false

--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -26,8 +26,8 @@ $:.unshift File.expand_path('lib', root)
 render_extensions = {}
 parse_extensions = {}
 
-# Default renderer
-renderer = Redcarpet::Render::HTML
+default_renderer = Redcarpet::Render::HTML
+renderer = default_renderer
 
 ARGV.delete_if do |arg|
   if arg =~ /^--render-([\w-]+)$/
@@ -38,6 +38,11 @@ ARGV.delete_if do |arg|
     parse_extensions[arg.to_sym] = true
   elsif arg =~ /^--([\w-]+)$/
     arg = $1.gsub('-', '_')
+
+    if renderer != default_renderer
+        raise "You can only specify one custom renderer."
+    end
+
     case arg
     when "smarty"
         renderer = Redcarpet::Render::SmartyHTML

--- a/lib/redcarpet/render_html_with_pygments.rb
+++ b/lib/redcarpet/render_html_with_pygments.rb
@@ -11,7 +11,7 @@ module Redcarpet
       def block_code(code, language)
         # TODO Move this to init or setup block.
         if not PYGMENTS_AVAILABLE
-          raise "Pygments.rb must be installed."
+          raise "Pygments.rb must be installed and in your bundle to use the --pygments option."
         end
         Pygments.highlight(code, :lexer => language)
       end

--- a/lib/redcarpet/render_html_with_pygments.rb
+++ b/lib/redcarpet/render_html_with_pygments.rb
@@ -1,0 +1,20 @@
+begin
+  require 'pygments'
+  PYGMENTS_AVAILABLE = true
+rescue LoadError
+  PYGMENTS_AVAILABLE = false
+end
+
+module Redcarpet
+  module Render
+    class HTMLwithPygments < HTML
+      def block_code(code, language)
+        # TODO Move this to init or setup block.
+        if not PYGMENTS_AVAILABLE
+          raise "Pygments.rb must be installed."
+        end
+        Pygments.highlight(code, :lexer => language)
+      end
+    end
+  end
+end

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
     lib/redcarpet/compat.rb
     lib/redcarpet/render_man.rb
     lib/redcarpet/render_strip.rb
+    lib/redcarpet/render_html_with_pygments.rb
     redcarpet.gemspec
     test/test_helper.rb
     test/custom_render_test.rb


### PR DESCRIPTION
I have added redcarpet as a supported filter in dexy (http://dexy.it). As dexy is a Python package I am using the command line interface. I would like to support pygments syntax highlighting so needed to expose this via the command line.