### PR TITLE
Yield the humanized id of the headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+* Yield the humanized id of the headers
+
+  Using the `header` callback, it's now possible to get access to the
+  humanized generated id to easily keep tracking of the tree of headers
+  or simply handle the duplicate values easily.
+
+  Since the `HTML_TOC` and `HTML` objects both have this callback, it's
+  advisable to define a module and mix it in these objects to avoid
+  code duplication.
+
+  *Robin Dupret*
+
 * Allow using tabs between a reference's colon and its link
 
   Fix issue [#337](https://github.com/vmg/redcarpet/issues/337)
@@ -9,7 +21,7 @@
 * Make ordered lists preceded by paragraph parsed with `:lax_spacing`
 
   Previously, enabling the `:lax_spacing` option, if a paragraph was
-  followed by an ordered list it was unparsed and was part of the 
+  followed by an ordered list it was unparsed and was part of the
   paragraph but this is no more the case.
 
   *Robin Dupret*

--- a/README.markdown
+++ b/README.markdown
@@ -235,7 +235,7 @@ end
 * block_html(raw_html)
 * footnotes(content)
 * footnote_def(content, number)
-* header(text, header_level)
+* header(text, header_level, id)
 * hrule()
 * list(contents, list_type)
 * list_item(text, list_type)

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -279,7 +279,7 @@ char *header_id(const struct buf *text)
 }
 
 static void
-rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
+rndr_header(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
@@ -287,7 +287,7 @@ rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 		bufputc(ob, '\n');
 
 	if ((options->flags & HTML_TOC) && (level <= options->toc_data.nesting_level))
-		bufprintf(ob, "<h%d id=\"%s\">", level, header_id(text));
+		bufprintf(ob, "<h%d id=\"%s\">", level, anchor);
 	else
 		bufprintf(ob, "<h%d>", level);
 
@@ -607,7 +607,7 @@ rndr_footnote_ref(struct buf *ob, unsigned int num, void *opaque)
 }
 
 static void
-toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
+toc_header(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
@@ -635,7 +635,7 @@ toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 			BUFPUTSL(ob,"</li>\n<li>\n");
 		}
 
-		bufprintf(ob, "<a href=\"#%s\">", header_id(text));
+		bufprintf(ob, "<a href=\"#%s\">", anchor);
 		if (text) escape_html(ob, text->data, text->size);
 		BUFPUTSL(ob, "</a>\n");
 	}

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -1712,7 +1712,7 @@ parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 		parse_inline(header_work, rndr, work.data, work.size);
 
 		if (rndr->cb.header)
-			rndr->cb.header(ob, header_work, (int)level, rndr->opaque);
+			rndr->cb.header(ob, header_work, (int)level, header_id(header_work), rndr->opaque);
 
 		rndr_popbuf(rndr, BUFFER_SPAN);
 	}
@@ -1992,7 +1992,7 @@ parse_atxheader(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 		parse_inline(work, rndr, data + i, end - i);
 
 		if (rndr->cb.header)
-			rndr->cb.header(ob, work, (int)level, rndr->opaque);
+			rndr->cb.header(ob, work, (int)level, header_id(work), rndr->opaque);
 
 		rndr_popbuf(rndr, BUFFER_SPAN);
 	}

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -67,7 +67,7 @@ struct sd_callbacks {
 	void (*blockcode)(struct buf *ob, const struct buf *text, const struct buf *lang, void *opaque);
 	void (*blockquote)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*blockhtml)(struct buf *ob,const  struct buf *text, void *opaque);
-	void (*header)(struct buf *ob, const struct buf *text, int level, void *opaque);
+	void (*header)(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque);
 	void (*hrule)(struct buf *ob, void *opaque);
 	void (*list)(struct buf *ob, const struct buf *text, int flags, void *opaque);
 	void (*listitem)(struct buf *ob, const struct buf *text, int flags, void *opaque);

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -61,9 +61,9 @@ rndr_raw_block(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static void
-rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
+rndr_header(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque)
 {
-	BLOCK_CALLBACK("header", 2, buf2str(text), INT2FIX(level));
+	BLOCK_CALLBACK("header", 3, buf2str(text), INT2FIX(level), rb_str_new2(anchor));
 }
 
 static void

--- a/lib/redcarpet/render_strip.rb
+++ b/lib/redcarpet/render_strip.rb
@@ -36,7 +36,7 @@ module Redcarpet
         text + "\n"
       end
 
-      def header(text, header_level)
+      def header(text, header_level, id)
         text + "\n"
       end
     end

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -2,6 +2,12 @@
 require 'test_helper'
 
 class HTMLTOCRenderTest < Test::Unit::TestCase
+  class CustomTocRender < Redcarpet::Render::HTML_TOC
+    def header(text, level, id)
+      "<h#{level} id=\"foo-bar-#{id}\">#{text}</h1>"
+    end
+  end
+
   def setup
     @render = Redcarpet::Render::HTML_TOC
     @markdown = "# A title \n## A __nice__ subtitle\n## Another one \n### A sub-sub-title"
@@ -37,5 +43,13 @@ class HTMLTOCRenderTest < Test::Unit::TestCase
     assert_match /a-nice-subtitle/, output
     assert_match /another-one/, output
     assert_match /a-sub-sub-title/, output
+  end
+
+  def test_header_callback
+    renderer = Redcarpet::Markdown.new(CustomTocRender)
+    output = renderer.render(@markdown)
+
+    assert_match /A title/, output
+    assert_match /foo-bar-a-title/, output
   end
 end


### PR DESCRIPTION
Hello,

Using the `header` callback, it's now possible to get access to the humanized generated id to easily keep tracking of the tree of headers or simply handle the duplicate values easily.

Since the `HTML_TOC` and `HTML` objects both have this callback, it's advisable to define a module and mix it in these objects to avoid code duplication.

It should resolve #310 since it's now straightforward to customize the anchors (replacing the "&" with "and" for instance).

Have a nice day.
