### PR TITLE
Fix vmg/redcarpet#337 by checking also for tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* Allow using tabs between a reference's colon and its link
+
+  Fix issue [#337](https://github.com/vmg/redcarpet/issues/337)
+
+  *Juan Guerrero*
+
 * Make ordered lists preceded by paragraph parsed with `:lax_spacing`
 
   Previously, enabling the `:lax_spacing` option, if a paragraph was

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2606,11 +2606,11 @@ is_ref(const uint8_t *data, size_t beg, size_t end, size_t *last, struct link_re
 	i++;
 	if (i >= end || data[i] != ':') return 0;
 	i++;
-	while (i < end && data[i] == ' ') i++;
+	while (i < end && strchr("\t ", data[i])) i++;
 	if (i < end && (data[i] == '\n' || data[i] == '\r')) {
 		i++;
 		if (i < end && data[i] == '\r' && data[i - 1] == '\n') i++; }
-	while (i < end && data[i] == ' ') i++;
+	while (i < end && strchr("\t ", data[i])) i++;
 	if (i >= end) return 0;
 
 	/* link: whitespace-free sequence, optionally between angle brackets */
@@ -2626,7 +2626,7 @@ is_ref(const uint8_t *data, size_t beg, size_t end, size_t *last, struct link_re
 	else link_end = i;
 
 	/* optional spacer: (space | tab)* (newline | '\'' | '"' | '(' ) */
-	while (i < end && data[i] == ' ') i++;
+	while (i < end && strchr("\t ", data[i])) i++;
 	if (i < end && data[i] != '\n' && data[i] != '\r'
 			&& data[i] != '\'' && data[i] != '"' && data[i] != '(')
 		return 0;
@@ -2639,7 +2639,7 @@ is_ref(const uint8_t *data, size_t beg, size_t end, size_t *last, struct link_re
 	/* optional (space|tab)* spacer after a newline */
 	if (line_end) {
 		i = line_end + 1;
-		while (i < end && data[i] == ' ') i++; }
+		while (i < end && strchr("\t ", data[i])) i++; }
 
 	/* optional title: any non-newline sequence enclosed in '"()
 					alone on its line */

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -282,4 +282,9 @@ text
     assert_match /<ol>/, output
     assert_match /<li>Foo<\/li>/, output
   end
+
+  def test_references_with_tabs_after_colon
+    markdown = @markdown.render("[Link][id]\n[id]:\t\t\thttp://google.es")
+    html_equal '<p><a href="http://google.es">Link</a></p>', markdown
+  end
 end


### PR DESCRIPTION
As [this](https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/markdown.c#L2605) comment states, the colon after the reference id can be followed either by spaces or tabs but the code currently looks only for spaces.
