### PR TITLE
Improve Travis' feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install tidy
 
-install: bundle install --without=benchmark
+install: travis_retry bundle install --without=benchmark
 
 rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - rbx-2
+  - 2.1.0
+  - rbx
   - ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: rbx
 
 notifications:
   email: false


### PR DESCRIPTION
Hello,

This pull request adds 2.1.0 to the list of tested rubies but also keep ruby-head to be sure to be compatible with the current trunk since Ruby moved to semantic versioning, the release process is a bit faster.

Also simply test on the latest Rubinius version and allow failures on it until we can find an appropriate fix for the code introduced in #333.

We should also rely on the travis_retry command when running bundle install since the rake-compiler gem set up often generate a Bundler error.

Have a nice day.
