### PR TITLE
Add middot tests

### DIFF
--- a/test/smarty_html_test.rb
+++ b/test/smarty_html_test.rb
@@ -44,21 +44,21 @@ class SmartyHTMLTest < Test::Unit::TestCase
   end
 
   def test_that_smartyhtml_converts_middot_to_nbsp
-    rd = @smarty_markdown.render("I·stick")
+    rd = @smarty_markdown.render("I·stick").strip
     expected = "I&#160;stick"
-    assert rd.include?(expected), "\"#{rd}\" should contain \"#{expected}\""
+    assert rd.include?(expected), "'#{rd}\' should contain '#{expected}'"
   end
 
   def test_that_smartyhtml_converts_middots_to_one_nbsp
-    rd = @smarty_markdown.render("I··stick once")
+    rd = @smarty_markdown.render("I··stick once").strip
     expected = "I&#160;stick once"
-    assert rd.include?(expected), "\"#{rd}\" should contain \"#{expected}\""
+    assert rd.include?(expected), "'#{rd}\' should contain '#{expected}'"
   end
 
   def test_that_smartyhtml_ignores_middot_in_code
-    rd = @smarty_markdown.render("`middot · nbsp`")
+    rd = @smarty_markdown.render("`middot · nbsp`").strip
     expected = "middot · nbsp"
-    assert rd.include?(expected), "\"#{rd}\" should contain \"#{expected}\""
+    assert rd.include?(expected), "'#{rd}\' should contain '#{expected}'"
   end
 
 end


### PR DESCRIPTION
I start with middot `·` to nbsp `&#160;` test for #332. Note:
1. Two middots convert to _one_ nbsp. I don’t want crazy abuse of middots for styling purposes, like in the 90’s.
2. I convert the middot to the XML entity `&#160;` and not to `&nbsp;`. This allows to use the feature in atom feeds.

When this feature is implemented, I will add a new PR with the soft-hyphen feature. If I see how the middot is implemented, I can write it myself.
