### PR TITLE
Remove a compiler warning

### DIFF
--- a/ext/redcarpet/buffer.c
+++ b/ext/redcarpet/buffer.c
@@ -94,7 +94,7 @@ bufnew(size_t unit)
 
 /* bufnullterm: NULL-termination of the string array */
 const char *
-bufcstr(const struct buf *buf)
+bufcstr(struct buf *buf)
 {
 	assert(buf && buf->unit);
 

--- a/ext/redcarpet/buffer.h
+++ b/ext/redcarpet/buffer.h
@@ -55,7 +55,7 @@ int bufgrow(struct buf *, size_t);
 struct buf *bufnew(size_t) __attribute__ ((malloc));
 
 /* bufnullterm: NUL-termination of the string array (making a C-string) */
-const char *bufcstr(const struct buf *);
+const char *bufcstr(struct buf *);
 
 /* bufprefix: compare the beginning of a buffer with a string */
 int bufprefix(const struct buf *buf, const char *prefix);

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -265,7 +265,7 @@ rndr_linebreak(struct buf *ob, void *opaque)
 	return 1;
 }
 
-char *header_anchor(const struct buf *text)
+char *header_anchor(struct buf *text)
 {
 	VALUE str = rb_str_new2(bufcstr(text));
 	VALUE space_regex = rb_reg_new(" +", 2 /* length */, 0);

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -105,7 +105,7 @@ struct sd_callbacks {
 };
 
 /* header methods used internally in Redcarpet */
-char* header_anchor(const struct buf *text);
+char* header_anchor(struct buf *text);
 
 struct sd_markdown;
 


### PR DESCRIPTION
Hello,

In 7b48ac95, the `bufcstr` prototype has been changed. This lead to a warning since bufgrow is meant to change the allocated size to the given buffer but the latter is a const. Here's the warning:

```
compiling ../../../../ext/redcarpet/buffer.c
../../../../ext/redcarpet/buffer.c: In function ‘bufcstr’:
../../../../ext/redcarpet/buffer.c:104:2: warning: passing argument 1 of ‘bufgrow’ discards ‘const’ qualifier from pointer target type [enabled by default]
  if (buf->size + 1 <= buf->asize || bufgrow(buf, buf->size + 1) == 0) {
  ^
../../../../ext/redcarpet/buffer.c:53:1: note: expected ‘struct buf *’ but argument is of type ‘const struct buf *’
 bufgrow(struct buf *buf, size_t neosz)
 ^
```

@mattr- : Could you check if you still get a warning with this patch please ? :-)

Have a nice day.
