### PR TITLE
Autolink URL that contains CJK letters will raise ArgumentError.

### DIFF
--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -126,6 +126,12 @@ HTML
     html_equal exp, rd
   end
 
+  def test_auto_linked_argument_error
+    rd = render_with({ autolink: true }, "http://zh.wikipedia.org/wiki/码")
+    exp = %{<p><a href="http://zh.wikipedia.org/wiki/%E7%A0%81">http://zh.wikipedia.org/wiki/码</a></p>\n}
+    html_equal exp, rd
+  end
+
   def test_memory_leak_when_parsing_char_links
     @markdown.render(<<-leaks)
 2. Identify the wild-type cluster and determine all clusters


### PR DESCRIPTION
I'm using Ruby 2.1.1p76 on OS X 10.6.8. The follow is the test for this scenario.

Input url: http://zh.wikipedia.org/wiki/码

Render this url with `autolink` flag enabled will lead to `ArgumentError: invalid byte sequence in UTF-8`

```ruby
...

  def test_auto_linked_argument_error
    rd = render_with({ autolink: true }, "http://zh.wikipedia.org/wiki/码")
    exp = %{<p><a href="http://zh.wikipedia.org/wiki/%E7%A0%81">http://zh.wikipedia.org/wiki/码</a></p>\n}
    html_equal exp, rd
  end

...
```

When I Run: `ruby -Itest test/markdown_test.rb`

I get:

```
Error: test_auto_linked_argument_error(MarkdownTest)
  ArgumentError: invalid byte sequence in UTF-8
/Users/Mac/.rvm/gems/ruby-2.1.1/gems/nokogiri-1.6.1/lib/nokogiri/html/document_fragment.rb:27:in `initialize'
/Users/Mac/.rvm/gems/ruby-2.1.1/gems/nokogiri-1.6.1/lib/nokogiri/html/document_fragment.rb:14:in `new'
/Users/Mac/.rvm/gems/ruby-2.1.1/gems/nokogiri-1.6.1/lib/nokogiri/html/document_fragment.rb:14:in `parse'
/Users/Mac/dev2/redcarpet/test/test_helper.rb:15:in `html_equal'
test/markdown_test.rb:132:in `test_auto_linked_argument_error'
     129:   def test_auto_linked_argument_error
     130:     rd = render_with({ autolink: true }, "http://zh.wikipedia.org/wiki/码")
     131:     exp = %{<p><a href="http://zh.wikipedia.org/wiki/%E7%A0%81">http://zh.wikipedia.org/wiki/码</a></p>\n}
  => 132:     html_equal exp, rd
     133:   end
     134:
     135:   def test_memory_leak_when_parsing_char_links
```