### PR TITLE
Change MKDEXT_NO_INTRA_EMPHASIS to not start after alphanumerics

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -702,7 +702,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 	size_t ret;
 
 	if (rndr->ext_flags & MKDEXT_NO_INTRA_EMPHASIS) {
-		if (offset > 0 && !_isspace(data[-1]) && data[-1] != '>' && data[-1] != '(')
+		if (offset > 0 && isalnum(data[-1]) && data[-1] != '>' && data[-1] != '(')
 			return 0;
 	}
 

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -273,6 +273,10 @@ text
     markdown = "This is (**bold**) and this_is_not_italic!"
     html = "<p>This is (<strong>bold</strong>) and this_is_not_italic!</p>\n"
     assert_equal html, render_with({:no_intra_emphasis => true}, markdown)
+
+    markdown = "This is \"**bold**\""
+    html = "<p>This is &quot;<strong>bold</strong>&quot;</p>\n"
+    assert_equal html, render_with({:no_intra_emphasis => true}, markdown)
   end
 
   def test_ordered_lists_with_lax_spacing


### PR DESCRIPTION
**No behavior should change if the NO_INTRA_EMPHASIS flag is not set.** With it set, the following behavior changes should be seen:  (The parentheses in the following examples can be replaced by any non-alphanumeric character.)
- "(_italics_)" is italic
- "this(_is_)weird" italicizes the "is"
- 'This is "**bold**"' emboldens "bold"

We were already checking for non-alphanumerics  on the closing boundary; that is, `"_this_()"` would have rendered as italicized even though the closing underscore wasn't followed by a space. This commit just brings the same behavior to the opening underscore.

Credit for this patch goes to @bjhomer: bdolman/sundown@b6434972a27ee677db433fbca6452fc78f7c0435 and is submitted here with his permission.
