### PR TITLE
Enable emphasis in multi-byte sentences when no_intra_emphasis is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+* Enable emphasis inside of sentences in multi-byte languages when
+  `:no_intra_emphasis` is set.
+
+  *Chun-wei Kuo*
+
 * Avoid making `:no_intra_emphasis` only match spaces. This allows
   using emphasizes inside quotes when the option is enabled for
   instance.

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -333,6 +333,14 @@ free_footnote_list(struct footnote_list *list, int free_refs)
 	}
 }
 
+/*
+ Wrap isalnum so that characters outside of the ASCII range don't count.
+ */
+static inline int
+_isalnum(int c)
+{
+	return isalnum(c) && c < 0x7f;
+}
 
 /*
  * Check whether a char is a Markdown space.
@@ -364,7 +372,7 @@ is_mail_autolink(uint8_t *data, size_t size)
 
 	/* address is assumed to be: [-@._a-zA-Z0-9]+ with exactly one '@' */
 	for (i = 0; i < size; ++i) {
-		if (isalnum(data[i]))
+		if (_isalnum(data[i]))
 			continue;
 
 		switch (data[i]) {
@@ -400,14 +408,14 @@ tag_length(uint8_t *data, size_t size, enum mkd_autolink *autolink)
 	if (data[0] != '<') return 0;
 	i = (data[1] == '/') ? 2 : 1;
 
-	if (!isalnum(data[i]))
+	if (!_isalnum(data[i]))
 		return 0;
 
 	/* scheme test */
 	*autolink = MKDA_NOT_AUTOLINK;
 
 	/* try to find the beginning of an URI */
-	while (i < size && (isalnum(data[i]) || data[i] == '.' || data[i] == '+' || data[i] == '-'))
+	while (i < size && (_isalnum(data[i]) || data[i] == '.' || data[i] == '+' || data[i] == '-'))
 		i++;
 
 	if (i > 1 && data[i] == '@') {
@@ -600,7 +608,7 @@ parse_emph1(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 		if (data[i] == c && !_isspace(data[i - 1])) {
 
 			if (rndr->ext_flags & MKDEXT_NO_INTRA_EMPHASIS) {
-				if (i + i < size && isalnum(data[i + 1]))
+				if (i + i < size && _isalnum(data[i + 1]))
 					continue;
 			}
 
@@ -702,7 +710,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 	size_t ret;
 
 	if (rndr->ext_flags & MKDEXT_NO_INTRA_EMPHASIS) {
-		if (offset > 0 && isalnum(data[-1]))
+		if (offset > 0 && _isalnum(data[-1]))
 			return 0;
 	}
 
@@ -868,7 +876,7 @@ char_entity(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offs
 	if (end < size && data[end] == '#')
 		end++;
 
-	while (end < size && isalnum(data[end]))
+	while (end < size && _isalnum(data[end]))
 		end++;
 
 	if (end < size && data[end] == ';')

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -269,6 +269,7 @@ text
     assert render_with({:no_intra_emphasis => true}, "this fails: hello_world_") !~ /<em>/
     assert render_with({:no_intra_emphasis => true}, "this also fails: hello_world_#bye") !~ /<em>/
     assert render_with({:no_intra_emphasis => true}, "this works: hello_my_world") !~ /<em>/
+    assert render_with({:no_intra_emphasis => true}, "句中**粗體**測試") =~ /<strong>/
 
     markdown = "This is (**bold**) and this_is_not_italic!"
     html = "<p>This is (<strong>bold</strong>) and this_is_not_italic!</p>\n"


### PR DESCRIPTION
Currently the `:no_intra_emphasis` extension disables emphasis in multi-byte sentences.

That is not desirable, because words are not separated by spaces in multi-byte language like Chinese or Japanese.

For example, given the following sentence (in Chinese):

```
中文內無空白的**粗體**也應加粗。
```

should render like this:

中文內無空白的**粗體**也應加粗。

The two characters surrounded by asterisks should be bold. It renders correctly on Github but not on redcarpet (when `:no_intra_emphasis` is set).

This pull request fixes this issue by adding a `_isalnum` function checking if the given character is an ASCII alphanumeric character. (The code is borrowed from github-markdown.)

I hope this issue can get fixed so that multi-byte language users are freed from adding extra spaces into sentences. Thanks! :smiley: 
