### PR TITLE
Remove the yielding of anchors in the header callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 3.1.2
+
+* Remove the yielding of anchors in the `header` callback. This was
+  a breaking change between 3.0 and 3.1 as the method's arity changed.
+
 ## Version 3.1.1
 
 * Fix a segfault when parsing text with headers.

--- a/README.markdown
+++ b/README.markdown
@@ -235,7 +235,7 @@ end
 * block_html(raw_html)
 * footnotes(content)
 * footnote_def(content, number)
-* header(text, header_level, anchor)
+* header(text, header_level)
 * hrule()
 * list(contents, list_type)
 * list_item(text, list_type)

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -279,7 +279,7 @@ char *header_anchor(const struct buf *text)
 }
 
 static void
-rndr_header(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque)
+rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
@@ -287,7 +287,7 @@ rndr_header(struct buf *ob, const struct buf *text, int level, char *anchor, voi
 		bufputc(ob, '\n');
 
 	if ((options->flags & HTML_TOC) && (level <= options->toc_data.nesting_level))
-		bufprintf(ob, "<h%d id=\"%s\">", level, anchor);
+		bufprintf(ob, "<h%d id=\"%s\">", level, header_anchor(text));
 	else
 		bufprintf(ob, "<h%d>", level);
 
@@ -607,7 +607,7 @@ rndr_footnote_ref(struct buf *ob, unsigned int num, void *opaque)
 }
 
 static void
-toc_header(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque)
+toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 {
 	struct html_renderopt *options = opaque;
 
@@ -635,7 +635,7 @@ toc_header(struct buf *ob, const struct buf *text, int level, char *anchor, void
 			BUFPUTSL(ob,"</li>\n<li>\n");
 		}
 
-		bufprintf(ob, "<a href=\"#%s\">", anchor);
+		bufprintf(ob, "<a href=\"#%s\">", header_anchor(text));
 		if (text) escape_html(ob, text->data, text->size);
 		BUFPUTSL(ob, "</a>\n");
 	}

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -1712,7 +1712,7 @@ parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 		parse_inline(header_work, rndr, work.data, work.size);
 
 		if (rndr->cb.header)
-			rndr->cb.header(ob, header_work, (int)level, header_anchor(header_work), rndr->opaque);
+			rndr->cb.header(ob, header_work, (int)level, rndr->opaque);
 
 		rndr_popbuf(rndr, BUFFER_SPAN);
 	}
@@ -1992,7 +1992,7 @@ parse_atxheader(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 		parse_inline(work, rndr, data + i, end - i);
 
 		if (rndr->cb.header)
-			rndr->cb.header(ob, work, (int)level, header_anchor(work), rndr->opaque);
+			rndr->cb.header(ob, work, (int)level, rndr->opaque);
 
 		rndr_popbuf(rndr, BUFFER_SPAN);
 	}

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -67,7 +67,7 @@ struct sd_callbacks {
 	void (*blockcode)(struct buf *ob, const struct buf *text, const struct buf *lang, void *opaque);
 	void (*blockquote)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*blockhtml)(struct buf *ob,const  struct buf *text, void *opaque);
-	void (*header)(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque);
+	void (*header)(struct buf *ob, const struct buf *text, int level, void *opaque);
 	void (*hrule)(struct buf *ob, void *opaque);
 	void (*list)(struct buf *ob, const struct buf *text, int flags, void *opaque);
 	void (*listitem)(struct buf *ob, const struct buf *text, int flags, void *opaque);

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -61,9 +61,9 @@ rndr_raw_block(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static void
-rndr_header(struct buf *ob, const struct buf *text, int level, char *anchor, void *opaque)
+rndr_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 {
-	BLOCK_CALLBACK("header", 3, buf2str(text), INT2FIX(level), rb_str_new2(anchor));
+	BLOCK_CALLBACK("header", 2, buf2str(text), INT2FIX(level));
 }
 
 static void

--- a/lib/redcarpet/render_strip.rb
+++ b/lib/redcarpet/render_strip.rb
@@ -35,7 +35,7 @@ module Redcarpet
         text + "\n"
       end
 
-      def header(text, header_level, anchor)
+      def header(text, header_level)
         text + "\n"
       end
     end

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -2,12 +2,6 @@
 require 'test_helper'
 
 class HTMLTOCRenderTest < Test::Unit::TestCase
-  class CustomTocRender < Redcarpet::Render::HTML_TOC
-    def header(text, level, anchor)
-      "<h#{level} id=\"foo-bar-#{anchor}\">#{text}</h1>"
-    end
-  end
-
   def setup
     @render = Redcarpet::Render::HTML_TOC
     @markdown = "# A title \n## A __nice__ subtitle\n## Another one \n### A sub-sub-title"
@@ -43,13 +37,5 @@ class HTMLTOCRenderTest < Test::Unit::TestCase
     assert_match /a-nice-subtitle/, output
     assert_match /another-one/, output
     assert_match /a-sub-sub-title/, output
-  end
-
-  def test_header_callback
-    renderer = Redcarpet::Markdown.new(CustomTocRender)
-    output = renderer.render(@markdown)
-
-    assert_match /A title/, output
-    assert_match /foo-bar-a-title/, output
   end
 end


### PR DESCRIPTION
Hello,

This pull request basically reverts facd5c5a. We should not change any method's arity between point releases. I guess there is no easy solution here. The only option I'm seeing is to define an `anchor` method that the `header` callback would rely on but for now, we should include it in 3.2 I think.

I also took the liberty to create a `3-1-branch` branch as `master` seems more to target 3.2.0 than 3.1.2.

Fixes #352.

Have a nice day.
