### PR TITLE
use SVG to display Travis CI build testing status

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 Redcarpet is written with sugar, spice and everything nice
 ============================================================
 
-[![Build Status](https://travis-ci.org/vmg/redcarpet.png?branch=master)](https://travis-ci.org/vmg/redcarpet)
+[![Build Status](https://travis-ci.org/vmg/redcarpet.svg?branch=master)](https://travis-ci.org/vmg/redcarpet)
 
 Redcarpet is Ruby library for Markdown processing that smells like
 butterflies and popcorn.


### PR DESCRIPTION
Rationale:
- SVG looks better on mobile devices with high pixel density
- SVG file size is smaller
