### PR TITLE
Fix over-zealous backslash replacement

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -848,7 +848,7 @@ char_quote(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offse
 static size_t
 char_escape(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
 {
-	static const char *escape_chars = "\\`*_{}[]()#+-.!:|&<>^~=";
+	static const char *escape_chars = "`*_{}[]()#+-.!:|&<>^~=";
 	struct buf work = { 0, 0, 0, 0 };
 
 	if (size > 1) {

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -45,6 +45,12 @@ class MarkdownTest < Redcarpet::TestCase
     assert_equal expected, output
   end
 
+  def test_that_backslashes_escape_properly
+    output   = render("visit \\\\server\\path \\**now**")
+    expected = "<p>visit \\\\server\\path *<em>now</em>*</p>"
+    assert_equal expected, output
+  end
+
   # This isn't in the spec but is Markdown.pl behavior.
   def test_block_quotes_preceded_by_spaces
     output = render <<-Markdown.strip_heredoc


### PR DESCRIPTION
Hi,

Two things, the [first](https://github.com/jcheatham/redcarpet/commit/24127e19c97887016f492bf80a7f906ab7f6b4f8) is to fix the [current travis breakage](https://travis-ci.org/vmg/redcarpet/builds/25455860).  I wasn't sure why it started with the last build, but it seems like it was broken since the original commit, so maybe some library or gem update?  Just looks like the test just needed a \n though.

Second is for #214 ([specifically](https://github.com/vmg/redcarpet/issues/214#issuecomment-22977188)), didn't fix the original emphasis problem in that issue though, looks like that's in char_emphasis, which I'll try and take a look at that when I can.  I couldn't find any instances where the backslash needed to be escaped, but please let me know if there's some case I missed (example test would be awesome! :)

And of course please let me know if this needs something else/more to get merged.

Cheers!
