### PR TITLE
Add the escape_html option the README file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -149,6 +149,10 @@ Initializes an HTML renderer. The following flags are available:
 
 * `:no_styles`: do not generate any `<style>` tags.
 
+* `:escape_html`: escape any HTML tags. This option has precedence over
+`:no_styles`, `:no_links`, `:no_images` and `:filter_html` which means
+that any existing tag will be escaped instead of being removed.
+
 * `:safe_links_only`: only generate links for protocols which are considered
 safe.
 


### PR DESCRIPTION
Hello,

This is just a tiny pull request that adds the `:escape_html` option to the README file. This option has been added in vmg/sundown#85 but has never been documented while its behavior can be more or less unexpected.

Have a nice day.
