### PR TITLE
A hyphen and an equal should not be converted to heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* A hyphen and an equal should not be converted to heading.
+
+  *namusyaka*
+
 * Fix emphasis character escape sequence detection while mid-emphasis.
 
   *jcheatham*

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -1624,17 +1624,23 @@ static size_t
 parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
 {
 	size_t i = 0, end = 0;
-	int level = 0;
+	int level = 0, last_is_empty = 1;
 	struct buf work = { data, 0, 0, 0 };
 
 	while (i < size) {
 		for (end = i + 1; end < size && data[end - 1] != '\n'; end++) /* empty */;
 
-		if (is_empty(data + i, size - i))
+		if (is_empty(data + i, size - i)) {
+			last_is_empty = 1;
 			break;
+		}
 
-		if ((level = is_headerline(data + i, size - i)) != 0)
+		if (!last_is_empty && (level = is_headerline(data + i, size - i)) != 0) {
+			last_is_empty = 0;
 			break;
+		}
+
+		last_is_empty = 0;
 
 		if (is_atxheader(rndr, data + i, size - i) ||
 			is_hrule(data + i, size - i) ||

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -38,4 +38,12 @@ class HTMLTOCRenderTest < Redcarpet::TestCase
     assert_match /another-one/, output
     assert_match /a-sub-sub-title/, output
   end
+
+  def test_toc_heading_with_hyphen_and_equal
+    renderer = Redcarpet::Markdown.new(@render)
+    output = renderer.render("# Hello World\n\n-\n\n=")
+
+    assert_equal 1, output.scan("<li>").length
+    assert !output.include?('<a href=\"#\"></a>')
+  end
 end

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -149,6 +149,11 @@ HTML
     header
   end
 
+  def test_a_hyphen_and_a_equal_should_not_be_converted_to_heading
+    html_equal "<p>-</p>\n", @markdown.render("-")
+    html_equal "<p>=</p>\n", @markdown.render("=")
+  end
+
   def test_that_tables_flag_works
     text = <<EOS
  aaa | bbbb


### PR DESCRIPTION
Hello.
I guess a hyphen and an equal should not be converted to heading.
For example, this code will convert to heading.

``` ruby
redcarpet = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
redcarpet.render("-") #=> "<h2></h2>\n"
# But, I'd expected to get "<p>-</p>\n"
```

Also, this behavior leads to incorrect output of html_toc.

``` ruby
toc = Redcarpet::Markdown.new(Redcarpet::Render::HTML_TOC)
toc.render(<<-markdown) #=> "<ul>\n<li>\n<a href=\"#hello-world\">Hello World</a>\n<ul>\n<li>\n<a href=\"#\"></a>\n</li>\n</ul>\n</li>\n</ul>\n"
# Hello World

-
markdown
```

Please review, thanks.
