### PR TITLE
The `StripDown` render now displays links' URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+* The `StripDown` render object now displays the URL of links
+  along with the text. 
+
+  *Robin Dupret*
+
 * The RedCloth API compatibility layer is now deprecated.
 
   *Robin Dupret*

--- a/lib/redcarpet/render_strip.rb
+++ b/lib/redcarpet/render_strip.rb
@@ -26,9 +26,9 @@ module Redcarpet
         end
       end
 
-      # Other methods where the text content is in another argument
+      # Other methods where we don't return only a specific argument
       def link(link, title, content)
-        content
+        "#{content} (#{link})"
       end
 
       def image(link, title, content)

--- a/test/stripdown_render_test.rb
+++ b/test/stripdown_render_test.rb
@@ -29,4 +29,12 @@ class StripDownRender < Redcarpet::TestCase
 
     assert_equal expected, output
   end
+
+  def test_links
+    markdown = "Here's an [example](https://github.com)"
+    expected = "Here's an example (https://github.com)\n"
+    output   = @parser.render(markdown)
+
+    assert_equal expected, output
+  end
 end


### PR DESCRIPTION
Hello,

This pull request make the `StripDown` render object displays more readable texts as previously, the links' URL would simply have been removed from the output which can be a misleading behavior as people assume that links will be reachable.

Also refactored a bit the tests of this render object.

Fixes #404.

Have a nice day.
