### PR TITLE
Add a `Safe` renderer to deal with users' input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Changelog
 
+* Add a `Safe` renderer to deal with users' input. The `escape_html`
+  and `safe_links_only` options are turned on by default.
+
+  Moreover, the `block_code` callback removes the tag's class since
+  the user can basically set anything with the vanilla one.
+
+  *Robin Dupret*
+
 * HTML5 block-level tags are now recognized
 
   *silverhammermba*
 
 * The `StripDown` render object now displays the URL of links
-  along with the text. 
+  along with the text.
 
   *Robin Dupret*
 

--- a/lib/redcarpet.rb
+++ b/lib/redcarpet.rb
@@ -11,14 +11,51 @@ module Redcarpet
 
     # XHTML Renderer
     class XHTML < HTML
-      def initialize(extensions={})
-        super(extensions.merge(:xhtml => true))
+      def initialize(extensions = {})
+        super(extensions.merge(xhtml: true))
       end
     end
 
     # HTML + SmartyPants renderer
     class SmartyHTML < HTML
       include SmartyPants
+    end
+
+    # A renderer object you can use to deal with users' input. It
+    # enables +escape_html+ and +safe_links_only+ by default.
+    #
+    # The +block_code+ callback is also overriden not to include
+    # the lang's class as the user can basically specify anything
+    # with the vanilla one.
+    class Safe < HTML
+      def initialize(extensions = {})
+        super({
+          escape_html: true,
+          safe_links_only: true
+        }.merge(extensions))
+      end
+
+      def block_code(code, lang)
+        "<pre>" \
+          "<code>#{html_escape(code)}</code>" \
+        "</pre>"
+      end
+
+      private
+
+      # TODO: This is far from ideal to have such method as we
+      # are duplicating existing code from Houdini. This method
+      # should be defined at the C level.
+      def html_escape(string)
+        string.gsub(/['&\"<>\/]/, {
+          '&' => '&amp;',
+          '<' => '&lt;',
+          '>' => '&gt;',
+          '"' => '&quot;',
+          "'" => '&#x27;',
+          "/" => '&#x2F',
+        })
+      end
     end
 
     # SmartyPants Mixin module

--- a/test/safe_render_test.rb
+++ b/test/safe_render_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class SafeRenderTest < Redcarpet::TestCase
+  def setup
+    @render = Redcarpet::Render::Safe
+    @parser = Redcarpet::Markdown.new(@render, fenced_code_blocks: true)
+  end
+
+  def test_safe_links_only_is_enabled_by_default
+    markdown = "[foo](javascript:alert('foo'))"
+    output   = @parser.render(markdown)
+
+    assert_not_match %r{a href}, output
+  end
+
+  def test_escape_html_is_enabled_by_default
+    markdown = "<p>Hello world!</p>"
+    output   = @parser.render(markdown)
+
+    assert_match %r{&lt;}, output
+  end
+
+  def test_html_escaping_in_code_blocks
+    markdown = "~~~\n<p>Hello!</p>\n~~~"
+    output   = @parser.render(markdown)
+
+    assert_match %r{&lt;p&gt;}, output
+  end
+
+  def test_lang_class_is_removed
+    markdown = "~~~ruby\nclass Foo; end\n~~~"
+    output   = @parser.render(markdown)
+
+    assert_not_match %r{ruby}, output
+  end
+end


### PR DESCRIPTION
Hello,

Since we can't turn on security options by default for the sake of backward compatibility, let's provide a new renderer object that will make it easy to deal with, for instance, users' input.

The `safe_links_only` and `escape_html` options are turned on by default but you can still override them if you prefer `filter_html` for example.

The `block_code` callback doesn't output any class attribute as this can be unsafe since we can specify existing classes as the language.

Fixes #375 and #384.

/cc @markijbema as discussed on HackerOne

Have a nice day.
