### PR TITLE
add indefinite article and update year

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Redcarpet is written with sugar, spice and everything nice
 
 [![Build Status](https://travis-ci.org/vmg/redcarpet.svg?branch=master)](https://travis-ci.org/vmg/redcarpet)
 
-Redcarpet is Ruby library for Markdown processing that smells like
+Redcarpet is a Ruby library for Markdown processing that smells like
 butterflies and popcorn.
 
 This library is written by people
@@ -335,7 +335,7 @@ inside the content of HTML tags and inside specific HTML blocks such as
 Boring legal stuff
 ------------------
 
-Copyright (c) 2011-2013, Vicent Martí
+Copyright (c) 2011-2014, Vicent Martí
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Probably the most meaningless pull request in history, but it's really bothering me. 
- Add "a" to make it read as "Redcarpet is **a** Ruby library..."
- Bump year to 2014 to help me feel less like a Grammar Nazi
