### PR TITLE
Make img src urls safe if safe_links_only is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+* Make img src urls safe if safe_links_only is enabled.
+  *Alex Serban*
 
 * Add a `Safe` renderer to deal with users' input. The `escape_html`
   and `safe_links_only` options are turned on by default.

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -429,7 +429,10 @@ static int
 rndr_image(struct buf *ob, const struct buf *link, const struct buf *title, const struct buf *alt, void *opaque)
 {
 	struct html_renderopt *options = opaque;
-	if (!link || !link->size) return 0;
+
+
+	if (link != NULL && (options->flags & HTML_SAFELINK) != 0 && !sd_autolink_issafe(link->data, link->size))
+		return 0;
 
 	BUFPUTSL(ob, "<img src=\"");
 	escape_href(ob, link->data, link->size);

--- a/test/safe_render_test.rb
+++ b/test/safe_render_test.rb
@@ -13,6 +13,13 @@ class SafeRenderTest < Redcarpet::TestCase
     assert_not_match %r{a href}, output
   end
 
+  def test_safe_image_src_is_enabled_by_default
+    markdown = "![foo](javascript:while(1);)"
+    output   = @parser.render(markdown)
+
+    assert_not_match %r{img src}, output
+  end
+
   def test_escape_html_is_enabled_by_default
     markdown = "<p>Hello world!</p>"
     output   = @parser.render(markdown)


### PR DESCRIPTION
Adding an image with src javascript:while(1); will freeze Firefox 32. I propose we make img srcs safe when safe_links_only is enabled.

/cc @robin850
