### PR TITLE
Don't autolink text if it's part of a previous inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Don't rewind into previous inlines when autolinking.
+
+  *Jordan Milne*
+
 ## Version 3.2.0
 
 * Add a `Safe` renderer to deal with users' input. The `escape_html`

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -461,7 +461,7 @@ tag_length(uint8_t *data, size_t size, enum mkd_autolink *autolink)
 static void
 parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size)
 {
-	size_t i = 0, end = 0;
+	size_t i = 0, end = 0, last_inline = 0;
 	uint8_t action = 0;
 	struct buf work = { 0, 0, 0, 0 };
 
@@ -486,12 +486,12 @@ parse_inline(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t siz
 		if (end >= size) break;
 		i = end;
 
-		end = markdown_char_ptrs[(int)action](ob, rndr, data + i, i, size - i);
+		end = markdown_char_ptrs[(int)action](ob, rndr, data + i, i - last_inline, size - i);
 		if (!end) /* no action from the callback */
 			end = i + 1;
 		else {
 			i += end;
-			end = i;
+			last_inline = end = i;
 		}
 	}
 }

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -126,6 +126,11 @@ HTML
     html_equal exp, rd
   end
 
+  def test_links_do_not_rewind_into_previous_inlines
+    rd = render_with({:autolink => true}, "__o__a@foo.http://example.com/")
+    html_equal "<p><strong>o</strong><a href=\"mailto:a@foo.http\">a@foo.http</a>://example.com/</p>\n", rd
+  end
+
   def test_memory_leak_when_parsing_char_links
     @markdown.render(<<-leaks)
 2. Identify the wild-type cluster and determine all clusters


### PR DESCRIPTION
Previously it was possible to get the renderer to truncate the
output at a point that would cause it to output unbalanced tags,
for ex.:

`__o__@bar.com` -> `<strong>o</st<a href="mailto:__o__@bar.com[…]`

Not great. This commit attempts to mitigate that by tracking the end
of the last inline and making sure rewinds don't run past it. This is
basically the approach taken by @vmg in vmg/rinku@dc685c1

The only issue with this approach I can think of is that we still can't autolink
bare emails like `foo_bar_baz@example.com` (issue #402), but that'd be difficult to handle
without a proper way to rewind over inlines in the output buffer.