### PR TITLE
Strip out non-alphanumeric chars from anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Non-alphanumeric chars are now stripped out from generated anchors
+  (along the lines of Active Support's `#parameterize` method).
+
 ## Version 3.2.0
 
 * Add a `Safe` renderer to deal with users' input. The `escape_html`

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -298,7 +298,15 @@ char *header_anchor(const struct buf *buffer)
 	/* Remove extra white spaces and lower case all
 	   characters ; also replace spaces with dashes */
 	for (i = 0, j = 0; i <= size; ++i) {
-		if (raw_string[i] == ' ' && raw_string[i+1] == ' ')
+		/* Collapse a stripped char surrounded by spaces
+		   to a single space (e.g. " + " -> " ") */
+		if (raw_string[i-1] == ' ' && raw_string[i+1] == ' '
+		    && STRIPPED_CHAR(raw_string[i]) && (i+1) < size)
+			i = i + 2;
+
+		/* Remove double spaces and stripped out chars */
+		if ((raw_string[i] == ' ' && raw_string[i+1] == ' ')
+		   || (STRIPPED_CHAR(raw_string[i]) && i < size))
 			continue;
 
 		if (raw_string[i] == ' ')

--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -73,6 +73,9 @@ sdhtml_smartypants(struct buf *ob, const uint8_t *text, size_t size);
 /* header method used internally in Redcarpet */
 char *header_anchor(const struct buf *buffer);
 
+#define STRIPPED_CHARS "&+$,/:;=?@\"#{}|^~[]`\\*()%.!'"
+#define STRIPPED_CHAR(x) (strchr(STRIPPED_CHARS, x) != NULL)
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -43,8 +43,19 @@ class HTMLTOCRenderTest < Redcarpet::TestCase
     assert !output.include?('<a href=\"#\"></a>')
   end
 
-  def test_toc_heading_with_extra_spaces
-    output = render("# First level  heading")
-    assert_match /#first-level-heading/, output
+  def test_anchor_generation_with_edge_cases
+    # Imported from ActiveSupport::Inflector#parameterize's tests
+    titles = {
+      "Donald E. Knuth"                     => "donald-e-knuth",
+      "Random text with *(bad)* characters" => "random-text-with-bad-characters",
+      "Trailing bad characters!@#"          => "trailing-bad-characters",
+      "!@#Leading bad characters"           => "leading-bad-characters",
+      "Squeeze   separators"                => "squeeze-separators",
+      "Test with + sign"                    => "test-with-sign"
+    }
+
+    titles.each do |title, anchor|
+      assert_match anchor, render("# #{title}")
+    end
   end
 end


### PR DESCRIPTION
Hello,

In order to generate valid anchors, let's remove non-alphanumeric chars from the output string. The generated strings are along the lines of strings returned by Active Support's `#parameterize`.

Fixes #385.

Have a nice day !
