### PR TITLE
Use lang attribute for code block languages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -167,6 +167,8 @@ Markdown document had newlines (by default, Markdown ignores these newlines).
 
 * `:prettify`: add prettyprint classes to `<code>` tags for google-code-prettify.
 
+* `:safe_lang`: use lang attribute for code block languages `<code lang="ruby">`.
+
 * `:link_attributes`: hash of extra attributes to add to links.
 
 Example:

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -124,8 +124,14 @@ rndr_blockcode(struct buf *ob, const struct buf *text, const struct buf *lang, v
 	if (lang && lang->size) {
 		size_t i, cls;
 		if (options->flags & HTML_PRETTIFY) {
-			BUFPUTSL(ob, "<pre><code class=\"prettyprint ");
+			if (options->flags & HTML_SAFE_LANG) {
+				BUFPUTSL(ob, "<pre><code class=\"prettyprint\" lang=\"");
+			} else {
+				BUFPUTSL(ob, "<pre><code class=\"prettyprint ");
+			}
 			cls++;
+		} else if (options->flags & HTML_SAFE_LANG) {
+			BUFPUTSL(ob, "<pre><code lang=\"");
 		} else {
 			BUFPUTSL(ob, "<pre><code class=\"");
 		}

--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -50,6 +50,7 @@ typedef enum {
 	HTML_USE_XHTML = (1 << 8),
 	HTML_ESCAPE = (1 << 9),
 	HTML_PRETTIFY = (1 << 10),
+	HTML_SAFE_LANG = (1 << 11),
 } html_render_mode;
 
 typedef enum {

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -422,6 +422,10 @@ static VALUE rb_redcarpet_html_init(int argc, VALUE *argv, VALUE self)
 		if (rb_hash_aref(hash, CSTR2SYM("escape_html")) == Qtrue)
 			render_flags |= HTML_ESCAPE;
 
+		/* safe_lang */
+		if (rb_hash_aref(hash, CSTR2SYM("safe_lang")) == Qtrue)
+			render_flags |= HTML_SAFE_LANG;
+
 		/* filter_html */
 		if (rb_hash_aref(hash, CSTR2SYM("filter_html")) == Qtrue)
 			render_flags |= HTML_SKIP_HTML;

--- a/lib/redcarpet/compat.rb
+++ b/lib/redcarpet/compat.rb
@@ -43,10 +43,11 @@ class RedcarpetCompat
     :gh_blockcode => nil,
     :no_tables    => nil,
     :smart        => nil,
-    :strict       => nil
+    :strict       => nil,
+    :safe_lang    => nil
   }
 
-  RENDERER_OPTIONS = [:filter_html, :no_images, :no_links, :no_styles,
+  RENDERER_OPTIONS = [:safe_lang, :filter_html, :no_images, :no_links, :no_styles,
     :safe_links_only, :with_toc_data, :hard_wrap, :prettify, :xhtml]
 
   def rename_extensions(exts)

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -12,7 +12,9 @@ class HTMLRenderTest < Redcarpet::TestCase
       :escape_html => Redcarpet::Render::HTML.new(:escape_html => true),
       :hard_wrap => Redcarpet::Render::HTML.new(:hard_wrap => true),
       :toc_data => Redcarpet::Render::HTML.new(:with_toc_data => true),
-      :prettify => Redcarpet::Render::HTML.new(:prettify => true)
+      :prettify => Redcarpet::Render::HTML.new(:prettify => true),
+      :safe_lang => Redcarpet::Render::HTML.new(:safe_lang => true),
+      :safe_lang_prettify => Redcarpet::Render::HTML.new(:safe_lang => true, :prettify => true)
     }
   end
 
@@ -212,6 +214,42 @@ Markdown
     output = renderer.render(text)
 
     assert output.include?("<code class=\"prettyprint ruby\">")
+  end
+
+  def test_that_safe_lang_works
+    text = <<-Markdown
+Foo
+
+~~~ruby
+some
+code
+~~~
+
+Bar
+Markdown
+
+    renderer = Redcarpet::Markdown.new(@rndr[:safe_lang], fenced_code_blocks: true)
+    output = renderer.render(text)
+
+    assert output.include?("<code lang=\"ruby\">")
+  end
+
+  def test_that_safe_lang_and_prettify_works
+    text = <<-Markdown
+Foo
+
+~~~ruby
+some
+code
+~~~
+
+Bar
+Markdown
+
+    renderer = Redcarpet::Markdown.new(@rndr[:safe_lang_prettify], fenced_code_blocks: true)
+    output = renderer.render(text)
+
+    assert output.include?("<code class=\"prettyprint\" lang=\"ruby\">")
   end
 
   def test_safe_links_only_with_anchors


### PR DESCRIPTION
Using language classes allows users to add any class to the page. Setting :safe_lang to true will use a lang attribute instead.

@robin850, was there any other reason for overriding #block_code in the Safe renderer, or could that be replaced by defaulting :safe_lang to true?
