### PR TITLE
Avoid HTML escaping for table-of-contents' titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Avoid escaping table-of-contents' headers by default. A new
+  `:escape_html` option is now available for the `HTML_TOC` object
+  if there are security concerns.
+
 * Add the `lang-` prefix in front of the language's name when using
   `:prettify` along with `:fenced_code_blocks`.
 

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -678,7 +678,14 @@ toc_header(struct buf *ob, const struct buf *text, int level, void *opaque)
 		}
 
 		bufprintf(ob, "<a href=\"#%s\">", header_anchor(text));
-		if (text) escape_html(ob, text->data, text->size);
+
+		if (text) {
+			if (options->flags & HTML_ESCAPE)
+				escape_html(ob, text->data, text->size);
+			else
+				bufput(ob, text->data, text->size);
+		}
+
 		BUFPUTSL(ob, "</a>\n");
 	}
 }
@@ -703,7 +710,7 @@ toc_finalize(struct buf *ob, void *opaque)
 }
 
 void
-sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options)
+sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, unsigned int render_flags)
 {
 	static const struct sd_callbacks cb_default = {
 		NULL,
@@ -744,7 +751,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 	};
 
 	memset(options, 0x0, sizeof(struct html_renderopt));
-	options->flags = HTML_TOC;
+	options->flags = render_flags;
 
 	memcpy(callbacks, &cb_default, sizeof(struct sd_callbacks));
 }

--- a/ext/redcarpet/html.h
+++ b/ext/redcarpet/html.h
@@ -65,7 +65,7 @@ extern void
 sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options_ptr, unsigned int render_flags);
 
 extern void
-sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options_ptr);
+sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options_ptr, unsigned int render_flags);
 
 extern void
 sdhtml_smartypants(struct buf *ob, const uint8_t *text, size_t size);

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -472,6 +472,7 @@ static VALUE rb_redcarpet_html_init(int argc, VALUE *argv, VALUE self)
 static VALUE rb_redcarpet_htmltoc_init(int argc, VALUE *argv, VALUE self)
 {
 	struct rb_redcarpet_rndr *rndr;
+	unsigned int render_flags = HTML_TOC;
 	VALUE hash, nesting_level = Qnil;
 
 	Data_Get_Struct(self, struct rb_redcarpet_rndr, rndr);
@@ -479,11 +480,15 @@ static VALUE rb_redcarpet_htmltoc_init(int argc, VALUE *argv, VALUE self)
 	if (rb_scan_args(argc, argv, "01", &hash) == 1) {
 		Check_Type(hash, T_HASH);
 
+		/* escape_html */
+		if (rb_hash_aref(hash, CSTR2SYM("escape_html")) == Qtrue)
+			render_flags |= HTML_ESCAPE;
+
 		/* Nesting level */
 		nesting_level = rb_hash_aref(hash, CSTR2SYM("nesting_level"));
 	}
 
-	sdhtml_toc_renderer(&rndr->callbacks, (struct html_renderopt *)&rndr->options.html);
+	sdhtml_toc_renderer(&rndr->callbacks, (struct html_renderopt *)&rndr->options.html, render_flags);
 	rb_redcarpet__overload(self, rb_cRenderHTML_TOC);
 
 	if (!(NIL_P(nesting_level)))

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -58,4 +58,18 @@ class HTMLTOCRenderTest < Redcarpet::TestCase
       assert_match anchor, render("# #{title}")
     end
   end
+
+  def test_inline_markup_is_not_escaped
+    output = render(@markdown)
+
+    assert_match "A <strong>nice</strong> subtitle", output
+    assert_no_match %r{&lt;}, output
+  end
+
+  def test_inline_markup_escaping
+    output = render(@markdown, with: [:escape_html])
+
+    assert_match "&lt;strong&gt;", output
+    assert_no_match %r{<strong>}, output
+  end
 end


### PR DESCRIPTION
Hello,

By default, the `HTML_TOC` render object used to HTML escape titles (see vmg/sundown#90) but in order to be consistent with other render objects, let's avoid this escaping and provide an `:escape_html` option.

Thus, the default behavior is more expected but it's still possible to safely display titles.

Fixes #255.

Have a nice day.
