### PR TITLE
Load `RedcarpetCompat` when requiring 'redcarpet'

### DIFF
--- a/lib/redcarpet.rb
+++ b/lib/redcarpet.rb
@@ -1,4 +1,5 @@
 require 'redcarpet.so'
+require 'redcarpet/compat'
 
 module Redcarpet
   VERSION = '3.2.0'


### PR DESCRIPTION
Fixes a backward incompatible change introduced in v3.2.0 via #401.
