### PR TITLE
Provide a `Redcarpet::CLI` class to create custom binary files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* Provide a `Redcarpet::CLI` class to create custom binary files.
+
+  Relying on Ruby's OptionParser, it's now straightforward to add new
+  options, rely on custom render objects or handle differently the
+  rendering of the provided files.
+
 * Undeprecate the compatibility layer for the old RedCloth API.
 
   This layer actually ease the support of libraries supporting different

--- a/bin/redcarpet
+++ b/bin/redcarpet
@@ -1,43 +1,7 @@
 #!/usr/bin/env ruby
-# Usage: redcarpet [--parse-<extension>...] [--render-<extension>...] [--smarty] [<file>...]
-# Convert one or more Markdown files to HTML and write to standard output. With
-# no <file> or when <file> is '-', read Markdown source text from standard input.
-# With <extension>s, perform additional Markdown processing before writing output.
-# With --smarty, use the SmartyHTML renderer
-if ARGV.include?('--help') or ARGV.include?('-h')
-  File.read(__FILE__).split("\n").grep(/^# /).each do |line|
-    puts line[2..-1]
-  end
-  exit 0
-end
+lib_path = File.expand_path('../../lib', __FILE__)
+$:.unshift(lib_path)
 
-require 'redcarpet'
+require 'redcarpet/cli'
 
-if ARGV.include?('--version') or ARGV.include?('-v')
-  puts "Redcarpet #{Redcarpet::VERSION}"
-  exit 0
-end
-
-root = File.expand_path('../../', __FILE__)
-$:.unshift File.expand_path('lib', root)
-
-render_extensions = {}
-parse_extensions = {}
-renderer = Redcarpet::Render::HTML
-
-ARGV.delete_if do |arg|
-  if arg =~ /^--render-([\w-]+)$/
-    arg = $1.gsub('-', '_')
-    render_extensions[arg.to_sym] = true
-  elsif arg =~ /^--parse-([\w-]+)$/
-    arg = $1.gsub('-', '_')
-    parse_extensions[arg.to_sym] = true
-  elsif arg == '--smarty'
-    renderer = Redcarpet::Render::SmartyHTML
-  else
-    false
-  end
-end
-
-render = renderer.new(render_extensions)
-STDOUT.write(Redcarpet::Markdown.new(render, parse_extensions).render(ARGF.read))
+Redcarpet::CLI.process(ARGV)

--- a/lib/redcarpet/cli.rb
+++ b/lib/redcarpet/cli.rb
@@ -1,0 +1,75 @@
+require 'redcarpet'
+require 'optparse'
+
+module Redcarpet
+  # This class aims at easing the creation of custom
+  # binary for your needs. For example, you can add new
+  # options or change the existing ones. The parsing
+  # is handled by Ruby's OptionParser. For instance:
+  #
+  #   class Custom::CLI < Redcarpet::CLI
+  #     def self.options_parser
+  #       super.tap do |opts|
+  #         opts.on("--rainbow") do
+  #           @@options[:rainbow] = true
+  #         end
+  #       end
+  #     end
+  #
+  #     def self.render_object
+  #       @@options[:rainbow] ? RainbowRender : super
+  #     end
+  #   end
+  class CLI
+    def self.options_parser
+      @@options = {
+        render_extensions: {},
+        parse_extensions: {},
+        smarty_pants: false
+      }
+
+      OptionParser.new do |opts|
+        opts.banner = "Usage: redcarpet [--parse <extension>...] " \
+                      "[--render <extension>...] [--smarty] <file>..."
+
+        opts.on("--parse EXTENSION", "Enable a parsing extension") do |ext|
+          ext = ext.gsub('-', '_').to_sym
+          @@options[:parse_extensions][ext] = true
+        end
+
+        opts.on("--render EXTENSION", "Enable a rendering extension") do |ext|
+          ext = ext.gsub('-', '_').to_sym
+          @@options[:render_extensions][ext] = true
+        end
+
+        opts.on("--smarty", "Enable Smarty Pants") do
+          @@options[:smarty_pants] = true
+        end
+
+        opts.on_tail("-v", "--version", "Display the current version") do
+          STDOUT.write "Redcarpet #{Redcarpet::VERSION}"
+          exit
+        end
+
+        opts.on_tail("-h", "--help", "Display this help message") do
+          puts opts
+          exit
+        end
+      end
+    end
+
+    def self.process(args)
+      self.options_parser.parse!(args)
+      STDOUT.write parser_object.render(ARGF.read)
+    end
+
+    def self.render_object
+      @@options[:smarty_pants] ? Render::SmartyHTML : Render::HTML
+    end
+
+    def self.parser_object
+      renderer = render_object.new(@@options[:render_extensions])
+      Redcarpet::Markdown.new(renderer, @@options[:parse_extensions])
+    end
+  end
+end

--- a/lib/redcarpet/cli.rb
+++ b/lib/redcarpet/cli.rb
@@ -59,6 +59,7 @@ module Redcarpet
     end
 
     def self.process(args)
+      self.legacy_parse!(args)
       self.options_parser.parse!(args)
       STDOUT.write parser_object.render(ARGF.read)
     end
@@ -70,6 +71,16 @@ module Redcarpet
     def self.parser_object
       renderer = render_object.new(@@options[:render_extensions])
       Redcarpet::Markdown.new(renderer, @@options[:parse_extensions])
+    end
+
+    def self.legacy_parse!(args) # :nodoc:
+      # Workaround for backward compatibility as OptionParser
+      # doesn't support the --flag-OPTION syntax.
+      args.select {|a| a =~ /--(parse|render)-/ }.each do |arg|
+        args.delete(arg)
+        arg = arg.partition(/\b-/)
+        args.push(arg.first, arg.last)
+      end
     end
   end
 end

--- a/test/redcarpet_bin_test.rb
+++ b/test/redcarpet_bin_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+require 'tempfile'
+
+class RedcarpetBinTest < Redcarpet::TestCase
+  def setup
+    @fixture_file = Tempfile.new('bin')
+    @fixture_path = @fixture_file.path
+
+    @fixture_file.write "A ==simple== fixture file -- with " \
+                        "a [link](https://github.com)."
+    @fixture_file.rewind
+  end
+
+  def teardown
+    @fixture_file.unlink
+  end
+
+  def test_vanilla_bin
+    run_bin(@fixture_path)
+
+    expected = "<p>A ==simple== fixture file -- with " \
+               "a <a href=\"https://github.com\">link</a>.</p>\n"
+
+    assert_equal expected, @output
+  end
+
+  def test_enabling_a_parse_option
+    run_bin("--parse-highlight", @fixture_path)
+
+    assert_output "<mark>"
+    refute_output "=="
+  end
+
+  def test_enabling_a_render_option
+    run_bin("--render-no-links", @fixture_path)
+
+    assert_output "[link]"
+    refute_output "</a>"
+  end
+
+  def test_enabling_smarty_pants
+    run_bin("--smarty", @fixture_path)
+
+    assert_output "&ndash"
+    refute_output "--"
+  end
+
+  def test_version_option
+    run_bin("--version")
+    assert_output "Redcarpet #{Redcarpet::VERSION}"
+  end
+
+  private
+
+  def run_bin(*args)
+    bin_path = File.expand_path('../../bin/redcarpet', __FILE__)
+
+    IO.popen("#{bin_path} #{args.join(" ")}") do |stream|
+      @output = stream.read
+    end
+  end
+
+  def assert_output(pattern)
+    assert_match pattern, @output
+  end
+
+  def refute_output(pattern)
+    refute_match Regexp.new(pattern), @output
+  end
+end

--- a/test/redcarpet_bin_test.rb
+++ b/test/redcarpet_bin_test.rb
@@ -25,14 +25,14 @@ class RedcarpetBinTest < Redcarpet::TestCase
   end
 
   def test_enabling_a_parse_option
-    run_bin("--parse-highlight", @fixture_path)
+    run_bin("--parse", "highlight", @fixture_path)
 
     assert_output "<mark>"
     refute_output "=="
   end
 
   def test_enabling_a_render_option
-    run_bin("--render-no-links", @fixture_path)
+    run_bin("--render", "no-links", @fixture_path)
 
     assert_output "[link]"
     refute_output "</a>"

--- a/test/redcarpet_bin_test.rb
+++ b/test/redcarpet_bin_test.rb
@@ -50,6 +50,16 @@ class RedcarpetBinTest < Redcarpet::TestCase
     assert_output "Redcarpet #{Redcarpet::VERSION}"
   end
 
+  def test_legacy_option_parsing
+    run_bin("--parse-highlight", "--render-no-links", @fixture_path)
+
+    assert_output "<mark>"
+    refute_output "=="
+
+    assert_output "[link]"
+    refute_output "</a>"
+  end
+
   private
 
   def run_bin(*args)


### PR DESCRIPTION
Hello,

This pull request introduces a new `Redcarpet::CLI` class that eases the creation of custom binary files (e.g. to address issues such as #327). Also our "binary" file was a bit  messy, it is now much more clear.

Moreover, at the moment, we are writing the output to `STDOUT`. Even though that's pretty easy to rely on `>>` inside the command line to write it to a file instead, it becomes a bit harder dealing with multiples files. For the sake of backward-compatibility, we should keep it as is but this is now simpler to handle differently the provided files.

Fixes #327.

Have a nice day!