### PR TITLE
fixing url generation from markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Avoid escaping ampersands in href links
+
+  *Nolan Evans*
+
 * Provide a `Redcarpet::CLI` class to create custom binary files.
 
   Relying on Ruby's OptionParser, it's now straightforward to add new

--- a/ext/redcarpet/houdini_href_e.c
+++ b/ext/redcarpet/houdini_href_e.c
@@ -22,10 +22,10 @@
  * have its native function (i.e. as an URL 
  * component/separator) and hence needs no escaping.
  *
- * There are two exceptions: the chacters & (amp)
- * and ' (single quote) do not appear in the table.
- * They are meant to appear in the URL as components,
- * yet they require special HTML-entity escaping
+ * There is one exception: the ' (single quote) 
+ * character does not appear in the table.
+ * It is meant to appear in the URL as components,
+ * however it require special HTML-entity escaping
  * to generate valid HTML markup.
  *
  * All other characters will be escaped to %XX.
@@ -34,7 +34,7 @@
 static const char HREF_SAFE[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 
+	0, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
 	1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 
@@ -73,12 +73,6 @@ houdini_escape_href(struct buf *ob, const uint8_t *src, size_t size)
 			break;
 
 		switch (src[i]) {
-		/* amp appears all the time in URLs, but needs
-		 * HTML-entity escaping to be inside an href */
-		case '&': 
-			BUFPUTSL(ob, "&amp;");
-			break;
-
 		/* the single quote is a valid URL character
 		 * according to the standard; it needs HTML
 		 * entity escaping too */

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -47,6 +47,12 @@ EOE
     assert_no_match %r{<img}, output
   end
 
+  def test_that_links_with_ampersands_work
+    markdown = %([/?a=b&c=d](/?a=b&c=d))
+    output   = render(markdown)
+    assert_equal "<p><a href=\"/?a=b&c=d\">/?a=b&amp;c=d</a></p>\n", output
+  end
+
   def test_that_no_links_flag_works
     markdown = %([This link](http://example.net/) <a href="links.html">links</a>)
     output   = render(markdown, with: [:no_links])

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -32,7 +32,7 @@ class MarkdownTest < Redcarpet::TestCase
 
   def test_that_urls_are_not_doubly_escaped
     markdown = @markdown.render('[Page 2](/search?query=Markdown+Test&page=2)')
-    assert_equal "<p><a href=\"/search?query=Markdown+Test&amp;page=2\">Page 2</a></p>\n", markdown
+    assert_equal "<p><a href=\"/search?query=Markdown+Test&page=2\">Page 2</a></p>\n", markdown
   end
 
   def test_simple_inline_html
@@ -287,7 +287,7 @@ indented
     markdown = render_with({:autolink => true}, <<text)
 This a stupid link: https://github.com/rtomayko/tilt/issues?milestone=1&state=open
 text
-    assert_equal "<p>This a stupid link: <a href=\"https://github.com/rtomayko/tilt/issues?milestone=1&amp;state=open\">https://github.com/rtomayko/tilt/issues?milestone=1&amp;state=open</a></p>\n", markdown
+    assert_equal "<p>This a stupid link: <a href=\"https://github.com/rtomayko/tilt/issues?milestone=1&state=open\">https://github.com/rtomayko/tilt/issues?milestone=1&amp;state=open</a></p>\n", markdown
   end
 
   def test_spaced_headers


### PR DESCRIPTION
There is a bug where ```&```'s in links get escaped to ```&amp;```. I believe the correct behavior is to not escape the & when it is a href attribute, and to continue escaping it when it is in the html element.

Bug:
```
require 'redcarpet'
renderer = Redcarpet::Render::HTML.new
s = '[/z?a=b&c=d](/z?a=b&c=d)'
Redcarpet::Markdown.new(renderer).render(s)
```

Actual:
```
=> "<p><a href=\"/z?a=b&amp;c=d\">/z?a=b&amp;c=d</a></p>\n"
```

Expected:
```
=> "<p><a href=\"/z?a=b&c=d\">/z?a=b&amp;c=d</a></p>\n"
```