### PR TITLE
Fix issue of UTF-8 belows the autolinked email address.

### DIFF
--- a/ext/redcarpet/autolink.c
+++ b/ext/redcarpet/autolink.c
@@ -224,7 +224,7 @@ sd_autolink__email(
 	for (link_end = 0; link_end < size; ++link_end) {
 		uint8_t c = data[link_end];
 
-		if (isalnum(c))
+		if (isalnum(c) && c < 0x7f)
 			continue;
 
 		if (c == '@')

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -126,6 +126,12 @@ HTML
     assert_equal exp, rd
   end
 
+  def test_auto_linked_email_utf8_issue
+		rd = render_with({ autolink: true }, "a@b.c」\nd@example.coü")
+		exp = %{<p><a href="mailto:a@b.c">a@b.c</a>」\n<a href="mailto:d@example.co">d@example.co</a>ü</p>\n}
+    assert_equal exp, rd
+  end
+
   def test_memory_leak_when_parsing_char_links
     @markdown.render(<<-leaks)
 2. Identify the wild-type cluster and determine all clusters


### PR DESCRIPTION
See https://github.com/vmg/redcarpet/issues/388 for more details.