### PR TITLE
Fix issue of UTF-8 belows the autolinked www link and url link.

### DIFF
--- a/ext/redcarpet/autolink.c
+++ b/ext/redcarpet/autolink.c
@@ -180,7 +180,7 @@ sd_autolink__www(
 	if (link_end == 0)
 		return 0;
 
-	while (link_end < size && !isspace(data[link_end]))
+	while (link_end < size && (!isspace(data[link_end]) || data[link_end] >= 0x7f))
 		link_end++;
 
 	link_end = autolink_delim(data, link_end, max_rewind, size);
@@ -280,7 +280,7 @@ sd_autolink__url(
 		return 0;
 
 	link_end += domain_len;
-	while (link_end < size && !isspace(data[link_end]))
+	while (link_end < size && (!isspace(data[link_end]) || data[link_end] >= 0x7f))
 		link_end++;
 
 	link_end = autolink_delim(data, link_end, max_rewind, size);

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -126,6 +126,20 @@ HTML
     assert_equal exp, rd
   end
 
+	# See https://github.com/vmg/redcarpet/pull/358 for more details
+  def test_auto_linked_www_utf8_issue
+		rd = render_with({ autolink: true }, "www.example.com/码")
+		exp = %{<p><a href="http://www.example.com/%E7%A0%81">www.example.com/码</a></p>\n}
+    assert_equal exp, rd
+  end
+
+	# See https://github.com/vmg/redcarpet/pull/358 for more details
+  def test_auto_linked_url_utf8_issue
+		rd = render_with({ autolink: true }, "http://example.com/码")
+    exp = %{<p><a href="http://example.com/%E7%A0%81">http://example.com/码</a></p>\n}
+    assert_equal exp, rd
+  end
+
   def test_memory_leak_when_parsing_char_links
     @markdown.render(<<-leaks)
 2. Identify the wild-type cluster and determine all clusters


### PR DESCRIPTION
Like https://github.com/vmg/redcarpet/pull/463 , this PR fixed the issue https://github.com/vmg/redcarpet/pull/358 .

Notice that always check the char is out of the UTF-8 range with `isalpha`, `isspace`, and other ASCII char detecting functions.