### PR TITLE
Use BUF_OK instead of magic number to evaluate bufgrow function

### DIFF
--- a/ext/redcarpet/buffer.c
+++ b/ext/redcarpet/buffer.c
@@ -101,7 +101,7 @@ bufcstr(const struct buf *buf)
 	if (buf->size < buf->asize && buf->data[buf->size] == 0)
 		return (char *)buf->data;
 
-	if (buf->size + 1 <= buf->asize || bufgrow(buf, buf->size + 1) == 0) {
+	if (buf->size + 1 <= buf->asize || bufgrow(buf, buf->size + 1) == BUF_OK) {
 		buf->data[buf->size] = 0;
 		return (char *)buf->data;
 	}
@@ -118,7 +118,7 @@ bufprintf(struct buf *buf, const char *fmt, ...)
 
 	assert(buf && buf->unit);
 
-	if (buf->size >= buf->asize && bufgrow(buf, buf->size + 1) < 0)
+	if (buf->size >= buf->asize && bufgrow(buf, buf->size + 1) < BUF_OK)
 		return;
 
 	va_start(ap, fmt);
@@ -136,7 +136,7 @@ bufprintf(struct buf *buf, const char *fmt, ...)
 	}
 
 	if ((size_t)n >= buf->asize - buf->size) {
-		if (bufgrow(buf, buf->size + n + 1) < 0)
+		if (bufgrow(buf, buf->size + n + 1) < BUF_OK)
 			return;
 
 		va_start(ap, fmt);
@@ -156,7 +156,7 @@ bufput(struct buf *buf, const void *data, size_t len)
 {
 	assert(buf && buf->unit);
 
-	if (buf->size + len > buf->asize && bufgrow(buf, buf->size + len) < 0)
+	if (buf->size + len > buf->asize && bufgrow(buf, buf->size + len) < BUF_OK)
 		return;
 
 	memcpy(buf->data + buf->size, data, len);
@@ -177,7 +177,7 @@ bufputc(struct buf *buf, int c)
 {
 	assert(buf && buf->unit);
 
-	if (buf->size + 1 > buf->asize && bufgrow(buf, buf->size + 1) < 0)
+	if (buf->size + 1 > buf->asize && bufgrow(buf, buf->size + 1) < BUF_OK)
 		return;
 
 	buf->data[buf->size] = c;


### PR DESCRIPTION
Hi there.

I noticed magic number when I debugged  `bufgrow` function.
So I replaced them to `BUF_OK`.