### PR TITLE
Append null-terminated string to buffer for markdown render

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -2879,6 +2879,9 @@ sd_markdown_render(struct buf *ob, const uint8_t *document, size_t doc_size, str
 	if (md->cb.doc_footer)
 		md->cb.doc_footer(ob, md->opaque);
 
+	/* appends null-terminated string */
+	bufcstr(ob);
+
 	/* clean-up */
 	bufrelease(text);
 	free_link_refs(md->refs);


### PR DESCRIPTION
Hi there.

I'd like to append Null-terminated character to parsed characters because...


> Working well on Objcetive-C.

```objc
NSString *html = [[NSString alloc] initWithBytes:ob->data length:ob->size encoding:NSUTF8StringEncoding];
```

> Sometimes, isn't working well because `ob->data` doesn't have `NULL` (`'\0'`) terminated character.

```objc
NSString *html = [[NSString alloc] initWithUTF8String:(const char *)ob->data];
```

----

Indeed, `initWithUTF8String` needs to detect null-terminated character.

```objc
- (instancetype)initWithUTF8String:(const char *)nullTerminatedCString;
```
(from NSString Header file)

Thank you for your consideration in advance.
