### PR TITLE
Avoid passing NULL value to escape_href on rndr_image

### DIFF
--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -482,7 +482,10 @@ rndr_image(struct buf *ob, const struct buf *link, const struct buf *title, cons
 		return 0;
 
 	BUFPUTSL(ob, "<img src=\"");
-	escape_href(ob, link->data, link->size);
+
+	if (link && link->size)
+		escape_href(ob, link->data, link->size);
+
 	BUFPUTSL(ob, "\" alt=\"");
 
 	if (alt && alt->size)
@@ -490,7 +493,8 @@ rndr_image(struct buf *ob, const struct buf *link, const struct buf *title, cons
 
 	if (title && title->size) {
 		BUFPUTSL(ob, "\" title=\"");
-		escape_html(ob, title->data, title->size); }
+		escape_html(ob, title->data, title->size);
+	}
 
 	bufputs(ob, USE_XHTML(options) ? "\"/>" : "\">");
 	return 1;


### PR DESCRIPTION
Hi there

I've fixed a bug which has a crash.


The bug is occured on creating image tag if passing NULL value to link on `rndr_image`.

For example:

- OK: `![](a)` 
- NG: `![]()`

Happened the crash because passing `link` value is not checked to use.

So, I added `if (link && link->size)`. (See 486 Lines)

And, I formatted brace. (See 496 Lines)

Thanks.


(I did noticed what there are no tests about image. I will make them.)