### PR TITLE
Prevent conversion to Emoji on iOS

### DIFF
--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -645,7 +645,7 @@ rndr_footnote_def(struct buf *ob, const struct buf *text, unsigned int num, void
 	bufprintf(ob, "\n<li id=\"fn%d\">\n", num);
 	if (pfound) {
 		bufput(ob, text->data, i);
-		bufprintf(ob, "&nbsp;<a href=\"#fnref%d\" rev=\"footnote\">&#8617;</a>", num);
+		bufprintf(ob, "&nbsp;<a href=\"#fnref%d\" rev=\"footnote\">&#8617;&#xfe0e;</a>", num);
 		bufput(ob, text->data + i, text->size - i);
 	} else if (text) {
 		bufput(ob, text->data, text->size);

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -141,7 +141,7 @@ MD
 <ol>
 
 <li id="fn1">
-<p>It provides additional information.&nbsp;<a href="#fnref1" rev="footnote">&#8617;</a></p>
+<p>It provides additional information.&nbsp;<a href="#fnref1" rev="footnote">&#8617;&#xfe0e;</a></p>
 </li>
 
 </ol>


### PR DESCRIPTION
Appending `&#xfe0e;` to the Unicode-represenation of the reversed arrow will prevent the conversion to an Emoji graphic on iOS. Take a look at this issue for better understanding: https://github.com/jekyll/jekyll/issues/3751