### PR TITLE
Fix redcarpet_bin_test for Windows

### DIFF
--- a/test/redcarpet_bin_test.rb
+++ b/test/redcarpet_bin_test.rb
@@ -64,8 +64,8 @@ class RedcarpetBinTest < Redcarpet::TestCase
 
   def run_bin(*args)
     bin_path = File.expand_path('../../bin/redcarpet', __FILE__)
-
-    IO.popen("#{bin_path} #{args.join(" ")}") do |stream|
+    ruby = "ruby " if RUBY_PLATFORM =~ /mswin|mingw/
+    IO.popen("#{ruby}#{bin_path} #{args.join(" ")}") do |stream|
       @output = stream.read
     end
   end


### PR DESCRIPTION
`redcarpet_bin_test.rb` failed on Windows.

```
Error: test_enabling_a_parse_option(RedcarpetBinTest): Errno::ENOEXEC: Exec format error - C:/work/vmg/redcarpet/bin/redcarpet --parse highlight C:/Temp/bin20151206-12624-1e7v3r8
C:/work/vmg/redcarpet/test/redcarpet_bin_test.rb:68:in `popen'
C:/work/vmg/redcarpet/test/redcarpet_bin_test.rb:68:in `run_bin'
C:/work/vmg/redcarpet/test/redcarpet_bin_test.rb:28:in `test_enabling_a_parse_option'
     25:   end
     26:
     27:   def test_enabling_a_parse_option
  => 28:     run_bin("--parse", "highlight", @fixture_path)
     29:
     30:     assert_output "<mark>"
     31:     refute_output "=="
```