### PR TITLE
Fix bufprintf for Windows MinGW-w64

### DIFF
--- a/ext/redcarpet/buffer.c
+++ b/ext/redcarpet/buffer.c
@@ -22,6 +22,7 @@
  */
 
 #define BUFFER_MAX_ALLOC_SIZE (1024 * 1024 * 16) //16mb
+#define __USE_MINGW_ANSI_STDIO 1
 
 #include "buffer.h"
 


### PR DESCRIPTION
On MinGW-w64, `vsnprintf` returns `-1` when given buffer is small (it should return required length as defined in C99).

Because of this, `bufprintf` sometime fails to write string to the given buffer, and header HTML tag
(such as `<h1>` and `</h1>`) isn't outputed occasionally.

Fix it by defining `__USE_MINGW_ANSI_STDIO`.
(see https://github.com/oneclick/rubyinstaller/issues/186 for detail)

Fixes #474