### PR TITLE
Prevent empty anchor if inserted chars don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+* Conform a rule of id attribute defined in HTML 4.01 specification
+
+  *namusyaka*
+
+* Prevent empty anchor if inserted chars do not exist
+
+  *namusyaka*
+
 * Multiple single quote pairs are parsed correctly with SmartyPants.
 
   Fix issue [#549](https://github.com/vmg/redcarpet/issues/549).

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -274,7 +274,7 @@ rndr_linebreak(struct buf *ob, void *opaque)
 static void
 rndr_header_anchor(struct buf *out, const struct buf *anchor)
 {
-	static const char *STRIPPED = " -&+$,/:;=?@\"#{}|^~[]`\\*()%.!'";
+	static const char *AVAILABLE_CHARS = "0123456789-_";
 	MD5_CTX ctx;
 	unsigned char md[MD5_LBLOCK];
 	int j = 0;
@@ -292,15 +292,15 @@ rndr_header_anchor(struct buf *out, const struct buf *anchor)
 			while (i < size && a[i] != ';')
 				i++;
 		}
-		else if (!(inserted || isalpha(a[i])) || !isascii(a[i]) || strchr(STRIPPED, a[i])) {
-			if (inserted && !stripped)
-				bufputc(out, '-');
-			stripped = 1;
-		}
-		else {
+		else if ((('a' <= a[i] && 'z' >= a[i]) || ('A' <= a[i] && 'Z' >= a[i]))
+			|| (inserted && strchr(AVAILABLE_CHARS, a[i]))) {
 			bufputc(out, tolower(a[i]));
 			stripped = 0;
 			inserted++;
+		}
+		else if (inserted && !stripped) {
+			bufputc(out, '-');
+			stripped = 1;
 		}
 	}
 

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -261,14 +261,14 @@ class HTMLRenderTest < Redcarpet::TestCase
 
   def test_non_ascii_only_header_anchors
     markdown = "# やあ諸君！"
-    html = "<h1 id=\"TOC_eab963056a69c89770528ba35a338be9\">やあ諸君！</h1>\n"
+    html = "<h1 id=\"TOC_eab963056a69c89770528ba35a338be9\">やあ諸君！</h1>"
 
     assert_equal html, render(markdown, with: [:with_toc_data])
   end
 
   def test_non_alphabet_char_at_first
     markdown = "# 1foo"
-    html = "<h1 id=\"foo\">1foo</h1>\n"
+    html = "<h1 id=\"foo\">1foo</h1>"
 
     assert_equal html, render(markdown, with: [:with_toc_data])
   end

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -258,4 +258,18 @@ class HTMLRenderTest < Redcarpet::TestCase
 
     assert_equal result, output
   end
+
+  def test_non_ascii_only_header_anchors
+    markdown = "# やあ諸君！"
+    html = "<h1 id=\"TOC_eab963056a69c89770528ba35a338be9\">やあ諸君！</h1>\n"
+
+    assert_equal html, render(markdown, with: [:with_toc_data])
+  end
+
+  def test_non_alphabet_char_at_first
+    markdown = "# 1foo"
+    html = "<h1 id=\"foo\">1foo</h1>\n"
+
+    assert_equal html, render(markdown, with: [:with_toc_data])
+  end
 end


### PR DESCRIPTION
Hi, I'd suggest the two changes.
1.  Prevent empty anchor if inserted chars don't exist

Current implementation has been ignoring characters until the first char is inserted.
This means that anchor text is empty until that.

_Behaviour_

``` markdown
# 你好

# aiueo

# あいうえお

# aいうえo

# あいうえo
```

``` html
<h1 id="TOC_7eca689f0d3389d9dea66ae112e5cfd7">你好</h1>

<h1 id="aiueo">aiueo</h1>

<h1 id="TOC_86deb27a32903da70a7b2348fcf36bc3">あいうえお</h1>

<h1 id="a-o">aいうえo</h1>

<h1 id="o">あいうえo</h1>
```

**Also, this changes might fix #538 .**
1. Conform a rule of id attribute defined in HTML 4.01 specification

In the rule of 4.01, id attribute value must be started with alphabet.
But in fact, HTML5 removed the rule.
However, if the rule is not supported, the markdown converted by redcarpet cannot conform 4.01 specification. So I think the behaviour should be respected.

_Behaviour_

``` markdown
# 1aiueo

# a1ueo
```

``` html
<h1 id="aiueo">1aiueo</h1>

<h1 id="a1ueo">a1ueo</h1>
```

Thanks.
