### PR TITLE
Include details of Redcarpet's plaintext renderer in the README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -185,9 +185,15 @@ When instantiating this render object, you can optionally pass a `nesting_level`
 option which takes an integer and allows you to make it render only headers
 until a specific level.
 
-Furthermore, the abstract base class `Redcarpet::Render::Base` can be used
-to write a custom renderer purely in Ruby, or extending an existing renderer.
-See the following section for more information.
+Redcarpet also includes a plaintext renderer, `Redcarpet::Render::StripDown`, that
+strips out all the formatting:
+
+~~~~ ruby
+require 'redcarpet/render_strip'
+markdown = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
+plaintext = markdown.render("**This** _is_ an [example](http://example.org/).")
+# => "This is an example (http://example.org/).\n"
+~~~~
 
 
 And you can even cook your own
@@ -207,8 +213,9 @@ end
 markdown = Redcarpet::Markdown.new(HTMLwithPygments, fenced_code_blocks: true)
 ~~~~~
 
-But new renderers can also be created from scratch (see `lib/redcarpet/render_man.rb` for
-an example implementation of a Manpage renderer)
+But new renderers can also be created from scratch by extending the abstract
+base class `Redcarpet::Render::Base` (see `lib/redcarpet/render_man.rb` for
+an example implementation of a Manpage renderer):
 
 ~~~~~~ ruby
 class ManPage < Redcarpet::Render::Base


### PR DESCRIPTION
I recently used Redcarpet in a project with Markdown content, and I needed to include some of that content in plaintext emails. For neatness' sake, I wanted to remove some of the formatting, and spent a little bit of time Googling for a way to do so with Redcarpet. It turned out that Redcarpet includes a plaintext renderer already (which is great!) but it wasn't listed in the README (which made it harder to discover). 

This changeset adds details of that renderer, and also removes some of the talk of custom renderers to that section. You might want to review this in its [rendered form](https://github.com/creature/redcarpet/blob/78be2efacb53418b19607b77e32722c42f99d4b1/README.markdown#and-its-like-really-simple-to-use) too. 