### PR TITLE
Give access to Markdown and rendering options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Expose the Markdown and rendering options through a `Hash` inside
+  the `@options` instance variable for custom render objects.
+
 * Avoid escaping ampersands in href links.
 
   *Nolan Evans*

--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -86,7 +86,7 @@ rb_redcarpet_md__free(void *markdown)
 
 static VALUE rb_redcarpet_md__new(int argc, VALUE *argv, VALUE klass)
 {
-	VALUE rb_markdown, rb_rndr, hash;
+	VALUE rb_markdown, rb_rndr, hash, rndr_options;
 	unsigned int extensions = 0;
 
 	struct rb_redcarpet_rndr *rndr;
@@ -102,6 +102,12 @@ static VALUE rb_redcarpet_md__new(int argc, VALUE *argv, VALUE klass)
 		rb_raise(rb_eTypeError, "Invalid Renderer instance given");
 
 	Data_Get_Struct(rb_rndr, struct rb_redcarpet_rndr, rndr);
+
+	/* Merge the current options in the @options hash */
+	if (hash != Qnil) {
+		rndr_options = rb_iv_get(rb_rndr, "@options");
+		rb_funcall(rndr_options, rb_intern("merge!"), 1, hash);
+	}
 
 	markdown = sd_markdown_new(extensions, 16, &rndr->callbacks, &rndr->options);
 	if (!markdown)

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -410,6 +410,9 @@ static void rb_redcarpet__overload(VALUE self, VALUE base_class)
 				dest[i] = source[i];
 		}
 	}
+
+	if (rb_iv_get(self, "@options") == Qnil)
+		rb_iv_set(self, "@options", rb_hash_new());
 }
 
 static VALUE rb_redcarpet_rbase_init(VALUE self)
@@ -428,6 +431,9 @@ static VALUE rb_redcarpet_html_init(int argc, VALUE *argv, VALUE self)
 
 	if (rb_scan_args(argc, argv, "01", &hash) == 1) {
 		Check_Type(hash, T_HASH);
+
+		/* Give access to the passed options through `@options` */
+		rb_iv_set(self, "@options", hash);
 
 		/* escape_html */
 		if (rb_hash_aref(hash, CSTR2SYM("escape_html")) == Qtrue)
@@ -490,6 +496,9 @@ static VALUE rb_redcarpet_htmltoc_init(int argc, VALUE *argv, VALUE self)
 
 	if (rb_scan_args(argc, argv, "01", &hash) == 1) {
 		Check_Type(hash, T_HASH);
+
+		/* Give access to the passed options through `@options` */
+		rb_iv_set(self, "@options", hash);
 
 		/* escape_html */
 		if (rb_hash_aref(hash, CSTR2SYM("escape_html")) == Qtrue)

--- a/test/custom_render_test.rb
+++ b/test/custom_render_test.rb
@@ -4,7 +4,15 @@ require 'test_helper'
 class CustomRenderTest < Redcarpet::TestCase
   class SimpleRender < Redcarpet::Render::HTML
     def emphasis(text)
-      "<em class=\"cool\">#{text}</em>"
+      if @options[:no_intra_emphasis]
+        return %(<em class="no_intra_emphasis">#{text}</em>)
+      end
+
+      %(<em class="cool">#{text}</em>)
+    end
+
+    def header(text, level)
+      "My little poney" if @options[:with_toc_data]
     end
   end
 
@@ -12,6 +20,20 @@ class CustomRenderTest < Redcarpet::TestCase
     md = Redcarpet::Markdown.new(SimpleRender)
     assert_equal "<p>This is <em class=\"cool\">just</em> a test</p>\n",
       md.render("This is *just* a test")
+  end
+
+  def test_renderer_options
+    parser = Redcarpet::Markdown.new(SimpleRender.new(with_toc_data: true))
+    output = parser.render("# A title")
+
+    assert_match "My little poney", output
+  end
+
+  def test_markdown_options
+    parser = Redcarpet::Markdown.new(SimpleRender, no_intra_emphasis: true)
+    output = parser.render("*foo*")
+
+    assert_match "no_intra_emphasis", output
   end
 
   class NilPreprocessRenderer < Redcarpet::Render::HTML


### PR DESCRIPTION
Hi !

This is just a pull request that exposes the Markdown and rendering options through the `@options` instance variable which is just a Hash which mixes both options. Thus, custom callbacks can return an output based upon these settings.

Closes #205.