### PR TITLE
Fix issue of handling multiple pairs of single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+* Multiple single quote pairs are parsed correctly.
+
+  Fix issue [#549](https://github.com/vmg/redcarpet/issues/549).
+
 * Table headers don't require a minimum of three dashes anymore; a
   single one can be used for each row.
 

--- a/ext/redcarpet/html_smartypants.c
+++ b/ext/redcarpet/html_smartypants.c
@@ -151,6 +151,9 @@ smartypants_squote(struct buf *ob, struct smartypants_data *smrt, uint8_t previo
 				return next_squote_len;
 		}
 
+		if (smartypants_quotes(ob, previous_char, size > 0 ? text[1] : 0, 's', &smrt->in_squote))
+			return 0;
+
 		// trailing single quotes: students', tryin'
 		if (word_boundary(t1)) {
 			BUFPUTSL(ob, "&rsquo;");
@@ -177,9 +180,6 @@ smartypants_squote(struct buf *ob, struct smartypants_data *smrt, uint8_t previo
 			}
 		}
 	}
-
-	if (smartypants_quotes(ob, previous_char, size > 0 ? text[1] : 0, 's', &smrt->in_squote))
-		return 0;
 
 	bufput(ob, squote_text, squote_size);
 	return 0;

--- a/test/smarty_pants_test.rb
+++ b/test/smarty_pants_test.rb
@@ -50,4 +50,9 @@ class SmartyPantsTest < Redcarpet::TestCase
     rd = @pants.render('I am 1/4... of the way to 1/4/2000')
     assert_equal "I am &frac14;&hellip; of the way to 1/4/2000", rd
   end
+
+  def test_that_smart_converts_multiple_single_quotes
+    rd = @pants.render(%(<p>'First' and 'second' and 'third'</p>))
+    assert_equal %(<p>&lsquo;First&rsquo; and &lsquo;second&rsquo; and &lsquo;third&rsquo;</p>), rd
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/vmg/redcarpet/issues/549

Trailing single quotes were treated by a [special case condition](https://github.com/vmg/redcarpet/blob/4f3a899191633a1da68156c925ff9eaee6d0b8f0/ext/redcarpet/html_smartypants.c#L155-L158) causing [`*is_open`](https://github.com/vmg/redcarpet/blob/4f3a899191633a1da68156c925ff9eaee6d0b8f0/ext/redcarpet/html_smartypants.c#L119) to remain true.