### PR TITLE
Addition to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -315,6 +315,12 @@ You can look at
 ["How to extend the Redcarpet 2 Markdown library?"](http://dev.af83.com/2012/02/27/howto-extend-the-redcarpet2-markdown-lib.html)
 for some more explanations.
 
+But where do I put it? (Handy Tips for Rails Users)
+------------------------------------
+
+There are a few options for where to include Redcarpet in your Rails app, but one 
+of the most straightforward is in `ApplicationHelper`.
+
 Also, now our Pants are much smarter
 ------------------------------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -333,9 +333,9 @@ module ApplicationHelper
 end
 ~~~~~
 
-And then include it in your view with the text you want to parse:
+And then call it in your view with the text you want to parse:
 
-~~~~ ruby
+~~~~ erb
 <div>
   <%= as_markdown(@object.description) %>
 </div>

--- a/README.markdown
+++ b/README.markdown
@@ -315,7 +315,7 @@ You can look at
 ["How to extend the Redcarpet 2 Markdown library?"](http://dev.af83.com/2012/02/27/howto-extend-the-redcarpet2-markdown-lib.html)
 for some more explanations.
 
-But where do I put it? (Handy Tips for Rails Users)
+But where do I put it? (A Handy Tip for Rails Users)
 ------------------------------------
 
 There are a few options for where to include Redcarpet in your Rails app, but one 
@@ -326,8 +326,8 @@ For example:
 ~~~~ ruby
 module ApplicationHelper
   def as_markdown(text)
-    renderer = Redcarpet::Render::HTML.new(render_options = {})
-    markdown = Redcarpet::Markdown.new(renderer, extensions = {})
+    renderer = Redcarpet::Render::HTML.new # include render_options as needed
+    markdown = Redcarpet::Markdown.new(renderer) # include extensions as needed
     markdown.render(text)
   end
 end

--- a/README.markdown
+++ b/README.markdown
@@ -319,7 +319,27 @@ But where do I put it? (Handy Tips for Rails Users)
 ------------------------------------
 
 There are a few options for where to include Redcarpet in your Rails app, but one 
-of the most straightforward is in `ApplicationHelper`.
+of the most straightforward is in your `ApplicationHelper`.
+
+For example:
+
+~~~~ ruby
+module ApplicationHelper
+  def as_markdown(text)
+    renderer = Redcarpet::Render::HTML.new(render_options = {})
+    markdown = Redcarpet::Markdown.new(renderer, extensions = {})
+    markdown.render(text)
+  end
+end
+~~~~~
+
+And then include it in your view with the text you want to parse:
+
+~~~~ ruby
+<div>
+  <%= as_markdown(@object.description) %>
+</div>
+~~~~~
 
 Also, now our Pants are much smarter
 ------------------------------------


### PR DESCRIPTION
Using Redcarpet for the first time today as a fairly newb Rails Dev, I noticed that it wasn't stated explicitly in the README where to include the instances of markdown and renderer in order to have access to them in the view to parse text. This PR makes a simple suggestion of where/how it can be added, as a way of helping other newbs out there who come across the same thing.
