### PR TITLE
Added support for html5 details and summary tags (Fixes #578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+* Added suppport for html5 details & summary tags
+
+  Fix issue [#578](https://github.com/vmg/redcarpet/issues/578).
+
+  *James Edwards-Jones*
+
 * Multiple single quote pairs are parsed correctly with SmartyPants.
 
   Fix issue [#549](https://github.com/vmg/redcarpet/issues/549).

--- a/ext/redcarpet/html_blocks.h
+++ b/ext/redcarpet/html_blocks.h
@@ -1,6 +1,6 @@
-/* C code produced by gperf version 3.0.4 */
+/* C code produced by gperf version 3.0.3 */
 /* Command-line: gperf -N find_block_tag -H hash_block_tag -C -c -E --ignore-case html_block_names.txt  */
-/* See http://git.io/RN0ncw for the list of recognized elements */
+/* See https://git.io/vPLqa for the list of recognized elements */
 /* Computed positions: -k'1-2' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
@@ -30,7 +30,7 @@
 error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
 #endif
 
-/* maximum key range = 67, duplicates = 0 */
+/* maximum key range = 72, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
@@ -94,34 +94,34 @@ hash_block_tag (str, len)
 {
   static const unsigned char asso_values[] =
     {
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      55, 50, 45, 40, 35, 30, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 15, 10, 15, 15, 15,
-       0, 20, 10, 10,  5, 68, 68,  0, 20, 25,
-       0, 68, 68,  0, 25,  0, 15, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 15, 10, 15,
-      15, 15,  0, 20, 10, 10,  5, 68, 68,  0,
-      20, 25,  0, 68, 68,  0, 25,  0, 15, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68, 68, 68, 68,
-      68, 68, 68, 68, 68, 68, 68
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      26, 60, 55, 45, 40, 35, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 20, 15, 15,  0, 35,
+       0, 25, 10, 10,  5, 73, 73,  0, 15, 15,
+       0, 73, 73, 15, 20, 10, 10, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 20, 15, 15,
+       0, 35,  0, 25, 10, 10,  5, 73, 73,  0,
+      15, 15,  0, 73, 73, 15, 20, 10, 10, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+      73, 73, 73, 73, 73, 73, 73
     };
-  register int hval = len;
+  register unsigned int hval = len;
 
   switch (hval)
     {
@@ -135,12 +135,6 @@ hash_block_tag (str, len)
   return hval;
 }
 
-#ifdef __GNUC__
-__inline
-#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
-__attribute__ ((__gnu_inline__))
-#endif
-#endif
 const char *
 find_block_tag (str, len)
      register const char *str;
@@ -148,76 +142,80 @@ find_block_tag (str, len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 41,
+      TOTAL_KEYWORDS = 43,
       MIN_WORD_LENGTH = 1,
       MAX_WORD_LENGTH = 10,
       MIN_HASH_VALUE = 1,
-      MAX_HASH_VALUE = 67
+      MAX_HASH_VALUE = 72
     };
 
   static const char * const wordlist[] =
     {
       "",
       "p",
-      "ul",
-      "pre",
-      "form",
-      "style",
-      "footer",
-      "section",
-      "", "", "",
-      "figure",
-      "hr",
-      "fieldset",
-      "math",
-      "figcaption",
-      "header",
       "dl",
       "del",
+      "form",
+      "",
+      "footer",
+      "details",
+      "div",
+      "", "",
+      "figure",
+      "ul",
+      "fieldset",
+      "",
+      "figcaption",
+      "header",
+      "ol",
+      "pre",
+      "math",
+      "video",
+      "script",
+      "section",
+      "noscript",
       "",
       "blockquote",
-      "script",
-      "article",
-      "div",
-      "",
-      "video",
       "hgroup",
-      "ol",
-      "noscript",
-      "", "",
-      "canvas",
-      "dd",
-      "nav",
-      "abbr",
-      "audio",
-      "iframe",
-      "address",
+      "hr",
       "ins",
       "",
+      "style",
+      "output",
+      "summary",
+      "nav",
+      "",
+      "audio",
+      "canvas",
+      "dd",
+      "h1",
+      "abbr",
       "table",
+      "iframe",
+      "article",
+      "", "",
+      "aside",
       "",
       "h6",
       "", "",
-      "aside",
-      "output",
-      "h5",
-      "", "",
       "tfoot",
       "",
+      "h5",
+      "", "", "", "",
       "h4",
+      "", "", "", "",
+      "address",
       "", "", "", "",
       "h3",
       "", "", "", "",
-      "h2",
-      "", "", "", "",
-      "h1"
+      "h2"
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = hash_block_tag (str, len);
+      unsigned int key = hash_block_tag (str, len);
 
-      if (key <= MAX_HASH_VALUE && key >= 0)
+      if (key <= MAX_HASH_VALUE)
         {
           register const char *s = wordlist[key];
 

--- a/test/html5_test.rb
+++ b/test/html5_test.rb
@@ -67,4 +67,16 @@ class HTML5Test < Redcarpet::TestCase
 
     assert_renders html, html
   end
+
+  def test_new_html5_tags_not_escaped
+    details = <<-HTML.chomp.strip_heredoc
+      <details>
+        log:
+
+      </details>
+    HTML
+
+    assert_renders details, details
+  end
+
 end


### PR DESCRIPTION
Added `<details>` and `<summary>` tags and regenerated `html_blocks.h`.

There are also some other tags missing which I could add if desired:

    main
    mark
    time

(Fixes #578)