### PR TITLE
Corrected the line ending for the version output.

### DIFF
--- a/lib/redcarpet/cli.rb
+++ b/lib/redcarpet/cli.rb
@@ -47,7 +47,7 @@ module Redcarpet
         end
 
         opts.on_tail("-v", "--version", "Display the current version") do
-          STDOUT.write "Redcarpet #{Redcarpet::VERSION}"
+          STDOUT.puts "Redcarpet #{Redcarpet::VERSION}"
           exit
         end
 


### PR DESCRIPTION
No line break as expected!

Now the `redcarpet --version` command correctly sets the line break
on the console. Using `IO#puts` since it provides the right record
separator on every OS.