### PR TITLE
Handle non-ASCII strings in header anchors 

### DIFF
--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -307,6 +307,15 @@ rndr_header_anchor(struct buf *out, const struct buf *anchor)
 	// replace the last dash if there was anything added
 	if (stripped && inserted)
 		out->size--;
+
+	// if anchor found empty, use djb2 hash for it
+	if (!inserted && anchor->size) {
+	        unsigned long hash = 5381;
+		for (i = 0; i < size; ++i) {
+			hash = ((hash << 5) + hash) + a[i]; /* h * 33 + c */
+		}
+		bufprintf(out, "part-%lx", hash);
+	}
 }
 
 static void

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -281,16 +281,20 @@ rndr_header_anchor(struct buf *out, const struct buf *anchor)
 	int stripped = 0, inserted = 0;
 
 	for (; i < size; ++i) {
+		// skip html tags
 		if (a[i] == '<') {
 			while (i < size && a[i] != '>')
 				i++;
+		// skip html entities
 		} else if (a[i] == '&') {
 			while (i < size && a[i] != ';')
 				i++;
 		}
+		// replace non-ascii or invalid characters with dashes
 		else if (!isascii(a[i]) || strchr(STRIPPED, a[i])) {
 			if (inserted && !stripped)
 				bufputc(out, '-');
+			// and do it only once
 			stripped = 1;
 		}
 		else {
@@ -300,7 +304,8 @@ rndr_header_anchor(struct buf *out, const struct buf *anchor)
 		}
 	}
 
-	if (stripped)
+	// replace the last dash if there was anything added
+	if (stripped && inserted)
 		out->size--;
 }
 

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -254,7 +254,7 @@ class HTMLRenderTest < Redcarpet::TestCase
 
   def test_utf8_only_header_anchors
     markdown = "# 見出し"
-    html = "<h1 id=\"\">見出し</h1>"
+    html = "<h1 id=\"part-37870bfa194139f\">見出し</h1>"
 
     assert_equal html, render(markdown, with: [:with_toc_data])
   end

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -252,6 +252,13 @@ class HTMLRenderTest < Redcarpet::TestCase
     assert_equal html, render(markdown, with: [:with_toc_data])
   end
 
+  def test_utf8_only_header_anchors
+    markdown = "# 見出し"
+    html = "<h1 id=\"\">見出し</h1>"
+
+    assert_equal html, render(markdown, with: [:with_toc_data])
+  end
+
   def test_escape_entities_removal_from_anchor
     output = render("# Foo's & Bar's", with: [:with_toc_data])
     result = %(<h1 id="foos-bars">Foo&#39;s &amp; Bar&#39;s</h1>)


### PR DESCRIPTION
Comes in two parts:
1. First we fix an issue with a dangling quote in 8d8e1eca1
2. Next, in f2d0ad99 we handle empty anchors with a [djb2 hash](http://www.cse.yorku.ca/~oz/hash.html) computed for the header

Overall it should fix #538 for Japanese and any other Unicode characters.

I considered adding heuristics to append a hash if more than X characters were removed, but decided against it because it may break someone's links. This may be beneficial if one have multiple headers in a foreign language that include some ASCII characters. Now every anchor for such headers would only contain said characters, giving duplicate anchors.

(sdbm implementation from `hash_link_ref` could be used instead of djb2, but that will introduce cross-dependencies)

Unlike #539 (which is also valid in principle) this change is self-contained. It doesn't depend on OpenSSL dev headers or anything else. Promise to require no installed libraries is kept.