### PR TITLE
Include cell header information in table_cell callback.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -257,7 +257,7 @@ end
 * paragraph(text)
 * table(header, body)
 * table_row(content)
-* table_cell(content, alignment)
+* table_cell(content, alignment, header)
 
 ### Span-level calls
 

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -114,8 +114,9 @@ static void
 rndr_tablecell(struct buf *ob, const struct buf *text, int align, void *opaque)
 {
 	VALUE rb_align;
+    VALUE rb_header;
 
-	switch (align) {
+    switch (align & MKD_TABLE_ALIGNMASK) {
 	case MKD_TABLE_ALIGN_L:
 		rb_align = CSTR2SYM("left");
 		break;
@@ -133,7 +134,13 @@ rndr_tablecell(struct buf *ob, const struct buf *text, int align, void *opaque)
 		break;
 	}
 
-	BLOCK_CALLBACK("table_cell", 2, buf2str(text), rb_align);
+    if (align & MKD_TABLE_HEADER) {
+        rb_header = INT2NUM(1);
+	} else {
+        rb_header = Qnil;
+	}
+
+	BLOCK_CALLBACK("table_cell", 3, buf2str(text), rb_align, rb_header);
 }
 
 static void

--- a/lib/redcarpet/render_strip.rb
+++ b/lib/redcarpet/render_strip.rb
@@ -52,7 +52,7 @@ module Redcarpet
         content + "\n"
       end
 
-      def table_cell(content, alignment)
+      def table_cell(content, alignment, header)
         content + "\t"
       end
     end


### PR DESCRIPTION
Copy flag bitmask logic from html.c to rc_render.c. 
Pass whether or not the cell is a header (th) to the table_cell callback. 
Update readme and render_strip to match.