### PR TITLE
Fix hashes in test suite for 32b architectures

### DIFF
--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -254,7 +254,13 @@ class HTMLRenderTest < Redcarpet::TestCase
 
   def test_utf8_only_header_anchors
     markdown = "# 見出し"
-    html = "<h1 id=\"part-37870bfa194139f\">見出し</h1>"
+    if 1.size == 4 # 32-bit architecture
+      html = "<h1 id=\"part-a194139f\">見出し</h1>"
+    elsif 1.size == 8 # 64-bit architecture
+      html = "<h1 id=\"part-37870bfa194139f\">見出し</h1>"
+    else
+      raise "unknown integer size"
+    end
 
     assert_equal html, render(markdown, with: [:with_toc_data])
   end

--- a/test/html_toc_render_test.rb
+++ b/test/html_toc_render_test.rb
@@ -54,7 +54,8 @@ class HTMLTOCRenderTest < Redcarpet::TestCase
     assert_match /a-nice-subtitle/, output
     assert_match /another-one/, output
     assert_match /a-sub-sub-title/, output
-    assert_match /part-37870bfa194139f/, output
+    # the part number length varies depending on architecture (32b or 64b)
+    assert_match /part-(37870bf)?a194139f/, output
   end
 
   def test_toc_heading_with_hyphen_and_equal


### PR DESCRIPTION
The hash length depends on integer size (32b/64b). Allow the test suite
to work on 32b architectures too.