### PR TITLE
Fix single quotes next to links for SmartyPants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+* Fix SmartyPants single quotes right after a link. For example:
+
+  ~~~markdown
+  [John](http://john.doe)'s cat
+  ~~~
+
+  Will now properly converts `'` to a right single quote (i.e. `’`).
+
+  Fixes #624.
+
 * Remove the `rel` and `rev` attributes from the output generated
   for footnotes as they don't pass the HTML 5 validation.
 

--- a/test/smarty_html_test.rb
+++ b/test/smarty_html_test.rb
@@ -42,4 +42,10 @@ class SmartyHTMLTest < Redcarpet::TestCase
     expected = "It&#39;s a test of &quot;code&quot;"
     assert rd.include?(expected), "\"#{rd}\" should contain \"#{expected}\""
   end
+
+  def test_that_smartyhtml_ignores_links_for_single_quotes
+    output = render("[John](link)'s cat")
+    expected = %(<p><a href="link">John</a>&rsquo;s cat</p>)
+    assert_equal expected, output
+  end
 end


### PR DESCRIPTION
Hello,

This pull request fixes single quotes next to links so that something like:

~~~markdown
[John](http://john.doe)'s cat
~~~

Will properly translates the single quote to a right single quote (i.e. `&rsquo;`).

Fixes #624.

Have a nice day.