### PR TITLE
Use Ruby's `ruby_xmalloc`

### DIFF
--- a/ext/redcarpet/buffer.c
+++ b/ext/redcarpet/buffer.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <ruby.h>
 
 /* MSVC compat */
 #if defined(_MSC_VER)
@@ -74,7 +75,7 @@ bufgrow(struct buf *buf, size_t neosz)
 	while (neoasz < neosz)
 		neoasz += buf->unit;
 
-	neodata = realloc(buf->data, neoasz);
+	neodata = ruby_xrealloc(buf->data, neoasz);
 	if (!neodata)
 		return BUF_ENOMEM;
 
@@ -89,7 +90,7 @@ struct buf *
 bufnew(size_t unit)
 {
 	struct buf *ret;
-	ret = malloc(sizeof (struct buf));
+	ret = ruby_xmalloc(sizeof (struct buf));
 
 	if (ret) {
 		ret->data = 0;
@@ -198,6 +199,6 @@ bufrelease(struct buf *buf)
 	if (!buf)
 		return;
 
-	free(buf->data);
-	free(buf);
+	ruby_xfree(buf->data);
+	ruby_xfree(buf);
 }

--- a/ext/redcarpet/buffer.c
+++ b/ext/redcarpet/buffer.c
@@ -76,8 +76,6 @@ bufgrow(struct buf *buf, size_t neosz)
 		neoasz += buf->unit;
 
 	neodata = ruby_xrealloc(buf->data, neoasz);
-	if (!neodata)
-		return BUF_ENOMEM;
 
 	buf->data = neodata;
 	buf->asize = neoasz;

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -220,9 +220,6 @@ add_link_ref(
 {
 	struct link_ref *ref = ruby_xcalloc(1, sizeof(struct link_ref));
 
-	if (!ref)
-		return NULL;
-
 	ref->id = hash_link_ref(name, name_size);
 	ref->next = references[ref->id % REF_TABLE_SIZE];
 
@@ -271,8 +268,6 @@ static struct footnote_ref *
 create_footnote_ref(struct footnote_list *list, const uint8_t *name, size_t name_size)
 {
 	struct footnote_ref *ref = ruby_xcalloc(1, sizeof(struct footnote_ref));
-	if (!ref)
-		return NULL;
 
 	ref->id = hash_link_ref(name, name_size);
 
@@ -283,8 +278,6 @@ static int
 add_footnote_ref(struct footnote_list *list, struct footnote_ref *ref)
 {
 	struct footnote_item *item = ruby_xcalloc(1, sizeof(struct footnote_item));
-	if (!item)
-		return 0;
 	item->ref = ref;
 
 	if (list->head == NULL) {

--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <ruby.h>
 
 #if defined(_WIN32)
 #define strncasecmp	_strnicmp
@@ -217,7 +218,7 @@ add_link_ref(
 	struct link_ref **references,
 	const uint8_t *name, size_t name_size)
 {
-	struct link_ref *ref = calloc(1, sizeof(struct link_ref));
+	struct link_ref *ref = ruby_xcalloc(1, sizeof(struct link_ref));
 
 	if (!ref)
 		return NULL;
@@ -260,7 +261,7 @@ free_link_refs(struct link_ref **references)
 			next = r->next;
 			bufrelease(r->link);
 			bufrelease(r->title);
-			free(r);
+			ruby_xfree(r);
 			r = next;
 		}
 	}
@@ -269,7 +270,7 @@ free_link_refs(struct link_ref **references)
 static struct footnote_ref *
 create_footnote_ref(struct footnote_list *list, const uint8_t *name, size_t name_size)
 {
-	struct footnote_ref *ref = calloc(1, sizeof(struct footnote_ref));
+	struct footnote_ref *ref = ruby_xcalloc(1, sizeof(struct footnote_ref));
 	if (!ref)
 		return NULL;
 
@@ -281,7 +282,7 @@ create_footnote_ref(struct footnote_list *list, const uint8_t *name, size_t name
 static int
 add_footnote_ref(struct footnote_list *list, struct footnote_ref *ref)
 {
-	struct footnote_item *item = calloc(1, sizeof(struct footnote_item));
+	struct footnote_item *item = ruby_xcalloc(1, sizeof(struct footnote_item));
 	if (!item)
 		return 0;
 	item->ref = ref;
@@ -318,7 +319,7 @@ static void
 free_footnote_ref(struct footnote_ref *ref)
 {
 	bufrelease(ref->contents);
-	free(ref);
+	ruby_xfree(ref);
 }
 
 static void
@@ -331,7 +332,7 @@ free_footnote_list(struct footnote_list *list, int free_refs)
 		next = item->next;
 		if (free_refs)
 			free_footnote_ref(item->ref);
-		free(item);
+		ruby_xfree(item);
 		item = next;
 	}
 }
@@ -2300,7 +2301,7 @@ parse_table_header(
 		pipes--;
 
 	*columns = pipes + 1;
-	*column_data = calloc(*columns, sizeof(int));
+	*column_data = ruby_xcalloc(*columns, sizeof(int));
 
 	/* Parse the header underline */
 	i++;
@@ -2409,7 +2410,7 @@ parse_table(
 			rndr->cb.table(ob, header_work, body_work, rndr->opaque);
 	}
 
-	free(col_data);
+	ruby_xfree(col_data);
 	rndr_popbuf(rndr, BUFFER_SPAN);
 	rndr_popbuf(rndr, BUFFER_BLOCK);
 	return i;
@@ -2741,7 +2742,7 @@ sd_markdown_new(
 
 	assert(max_nesting > 0 && callbacks);
 
-	md = malloc(sizeof(struct sd_markdown));
+	md = ruby_xmalloc(sizeof(struct sd_markdown));
 	if (!md)
 		return NULL;
 
@@ -2911,5 +2912,5 @@ sd_markdown_free(struct sd_markdown *md)
 	redcarpet_stack_free(&md->work_bufs[BUFFER_SPAN]);
 	redcarpet_stack_free(&md->work_bufs[BUFFER_BLOCK]);
 
-	free(md);
+	ruby_xfree(md);
 }

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -377,7 +377,7 @@ static void rb_redcarpet_rbase_mark(struct rb_redcarpet_rndr *rndr)
 
 static void rndr_deallocate(void *rndr)
 {
-  xfree(rndr);
+  ruby_xfree(rndr);
 }
 
 static VALUE rb_redcarpet_rbase_alloc(VALUE klass)

--- a/ext/redcarpet/stack.c
+++ b/ext/redcarpet/stack.c
@@ -33,8 +33,6 @@ redcarpet_stack_grow(struct stack *st, size_t new_size)
 		return 0;
 
 	new_st = ruby_xrealloc(st->item, new_size * sizeof(void *));
-	if (new_st == NULL)
-		return -1;
 
 	memset(new_st + st->asize, 0x0,
 		(new_size - st->asize) * sizeof(void *));

--- a/ext/redcarpet/stack.c
+++ b/ext/redcarpet/stack.c
@@ -22,6 +22,7 @@
 
 #include "stack.h"
 #include <string.h>
+#include <ruby.h>
 
 int
 redcarpet_stack_grow(struct stack *st, size_t new_size)
@@ -31,7 +32,7 @@ redcarpet_stack_grow(struct stack *st, size_t new_size)
 	if (st->asize >= new_size)
 		return 0;
 
-	new_st = realloc(st->item, new_size * sizeof(void *));
+	new_st = ruby_xrealloc(st->item, new_size * sizeof(void *));
 	if (new_st == NULL)
 		return -1;
 
@@ -53,7 +54,7 @@ redcarpet_stack_free(struct stack *st)
 	if (!st)
 		return;
 
-	free(st->item);
+	ruby_xfree(st->item);
 
 	st->item = NULL;
 	st->size = 0;

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -1,7 +1,7 @@
 # encoding: utf-8
 Gem::Specification.new do |s|
   s.name = 'redcarpet'
-  s.version = '3.4.0'
+  s.version = '3.5.0'
   s.summary = "Markdown that smells nice"
   s.description = 'A fast, safe and extensible Markdown to (X)HTML parser'
   s.date = '2016-12-25'


### PR DESCRIPTION
Right now, memory allocations in this library are done via `malloc`, however, we are not checking for `NULL` pointers in all of them, like in: https://github.com/vmg/redcarpet/pull/633#issuecomment-343580107

In case `malloc` fails, the received pointer is going to eventually be dereferenced, and this will cause the Ruby process to crash.

This PR replaces `malloc` usage by `ruby_xmalloc` (as well as their `free` counterparts), as it checks the allocation result. In case the allocation fails it will raise an error.

What do you think, @robin850? 😄 

cc/ @dylanahsmith