### PR TITLE
Run redcarpet in redcarpet_bin_test with the interpreter the test sta…

### DIFF
--- a/test/redcarpet_bin_test.rb
+++ b/test/redcarpet_bin_test.rb
@@ -64,8 +64,8 @@ class RedcarpetBinTest < Redcarpet::TestCase
 
   def run_bin(*args)
     bin_path = File.expand_path('../../bin/redcarpet', __FILE__)
-    ruby = "ruby " if RUBY_PLATFORM =~ /mswin|mingw/
-    IO.popen("#{ruby}#{bin_path} #{args.join(" ")}") do |stream|
+    ruby = RbConfig.ruby
+    IO.popen("#{ruby} #{bin_path} #{args.join(" ")}") do |stream|
       @output = stream.read
     end
   end


### PR DESCRIPTION
…rted with

This fixes test failure for Ruby 2.5 when Ruby 2.3 is the default installed
version.