### PR TITLE
Fix "instance variable @options not initialized" warning in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Fix `warning: instance variable @options not initialized` when
+  running under verbose mode (`-w`, `$VERBOSE = true`).
+
 * Fix SmartyPants single quotes right after a link. For example:
 
   ~~~markdown

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -390,6 +390,7 @@ static VALUE rb_redcarpet_rbase_alloc(VALUE klass)
 static void rb_redcarpet__overload(VALUE self, VALUE base_class)
 {
 	struct rb_redcarpet_rndr *rndr;
+	VALUE options_ivar;
 
 	Data_Get_Struct(self, struct rb_redcarpet_rndr, rndr);
 	rndr->options.self = self;
@@ -411,7 +412,8 @@ static void rb_redcarpet__overload(VALUE self, VALUE base_class)
 		}
 	}
 
-	if (rb_iv_get(self, "@options") == Qnil)
+	options_ivar = rb_attr_get(self, rb_intern("@options"));
+	if (options_ivar == Qundef || options_ivar == Qnil)
 		rb_iv_set(self, "@options", rb_hash_new());
 }
 


### PR DESCRIPTION
When running in verbose mode (`-w` or `--verbose` or `$VERBOSE = true`), when instantiating any renderer (subclass of `Redcarpet::Render::Base`) without parameters, warning is shown about `@options` not initialized:

```
warning: instance variable @options not initialized
```

(For example, it can be seen if running `RUBYOPT=-w rake test`)

It's caused by accessing `@options` with `rb_iv_get`:

https://github.com/vmg/redcarpet/blob/1c71f5edcd113d6eb8fcc17cde17878b8adcd3d0/ext/redcarpet/rc_render.c#L414-L415

Replaced it with `rb_attr_get`, [according to source](https://github.com/ruby/ruby/blob/015a415ee3e721f42be6e29168aed4c0fcd8e18f/variable.c#L1211-L1229), it's the same as `rb_ivar_get` but without warnings and without conversion of undef to nil, not sure if it's the right method by design (seems that it is).

Also not sure what is purpose for `@options` in render objects: there are no reads of it and all options are passed to actual renderer in constructor only, overwriting `@options` later is meaningless. `Redcarpet::Markdown` object [adds its options to it when initialized](https://github.com/vmg/redcarpet/blob/1c71f5edcd113d6eb8fcc17cde17878b8adcd3d0/ext/redcarpet/rc_markdown.c#L116-L120) but I can't figure out where these options are used (and these options are not for renderer but for "extensions"). Update: it's feature #560 and intended for custom renderers to be able to access "extension options" and not only renderer options passed in constructor.

I can try to detect warnings in tests, but I'm not sure if it's right idea (it can only be done in quirky ways such as capturing stderr), so not changed tests for now.