### PR TITLE
[BUG] Don't mutate passed configuration options

### DIFF
--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -115,8 +115,8 @@ static VALUE rb_redcarpet_md__new(int argc, VALUE *argv, VALUE klass)
 
 	/* Merge the current options in the @options hash */
 	if (hash != Qnil) {
-		rndr_options = rb_iv_get(rb_rndr, "@options");
-		rb_funcall(rndr_options, rb_intern("merge!"), 1, hash);
+		rndr_options = rb_funcall(rb_iv_get(rb_rndr, "@options"), rb_intern("merge"), 1, hash);
+		rb_iv_set(rb_rndr, "@options", rndr_options);
 	}
 
 	markdown = sd_markdown_new(extensions, 16, &rndr->callbacks, &rndr->options);

--- a/test/custom_render_test.rb
+++ b/test/custom_render_test.rb
@@ -23,7 +23,7 @@ class CustomRenderTest < Redcarpet::TestCase
   end
 
   def test_renderer_options
-    parser = Redcarpet::Markdown.new(SimpleRender.new(with_toc_data: true))
+    parser = Redcarpet::Markdown.new(SimpleRender.new({ with_toc_data: true }.freeze), {})
     output = parser.render("# A title")
 
     assert_match "My little poney", output


### PR DESCRIPTION
The markdown initializer mutates the options you pass it. I don't see any obvious reason why this is necessary?
```ruby
Redcarpet::Markdown.new(Redcarpet::Render::HTML.new({ bizzle: 'zizzle' }.freeze), {})

RuntimeError: can't modify frozen Hash
from (pry):5:in `merge!'
```

Instead just merge and return a new hash 👍 👎 🤷‍♂️ 