### PR TITLE
Only increase the size of the stack if required

### DIFF
--- a/ext/redcarpet/stack.c
+++ b/ext/redcarpet/stack.c
@@ -76,7 +76,7 @@ redcarpet_stack_init(struct stack *st, size_t initial_size)
 int
 redcarpet_stack_push(struct stack *st, void *item)
 {
-	if (redcarpet_stack_grow(st, st->size * 2) < 0)
+	if (st->size == st->asize && redcarpet_stack_grow(st, st->size * 2) < 0)
 		return -1;
 
 	st->item[st->size++] = item;


### PR DESCRIPTION
Hi! I was looking through this code for unrelated reasons and happened to notice that `redcarpet_stack_push` is calling `redcarpet_stack_grow` significantly more often than necessary. My assumption from reading the code is that it should only allocate more memory if their's insufficient space but this is increasing the buffer size on every `push` so there's always double the space required.

Your contributing guide says to add a test but as far as I can tell there's no way to test C code directly so I'm not sure that's a feasible thing to do in this case. Please let me know if there is a way to test this and I'd be happy to add it. This does not appear to effect the benchmark in any way.