### PR TITLE
Allow to preserve linebreaks with backslash

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -745,12 +745,16 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t of
 }
 
 
-/* char_linebreak • '\n' preceded by two spaces (assuming linebreak != 0) */
+/* char_linebreak • '\n' preceded by two spaces or backslash (assuming linebreak != 0) */
 static size_t
 char_linebreak(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t offset, size_t size)
 {
-	if (offset < 2 || data[-1] != ' ' || data[-2] != ' ')
+	if (!(offset >= 1 && data[-1] == '\\') && !(offset >= 2 && data[-1] == ' ' && data[-2] == ' '))
 		return 0;
+
+	/* removing escaping backslash if there was any */
+	if (ob->size && ob->data[ob->size - 1] == '\\')
+		ob->size--;
 
 	/* removing the last space from ob and rendering */
 	while (ob->size && ob->data[ob->size - 1] == ' ')

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -403,4 +403,25 @@ class MarkdownTest < Redcarpet::TestCase
 
     assert_match /<table>/, output
   end
+
+  def test_double_space_inserts_linebreak
+    result = %(<p>here comes a break:<br>\nThere it was.</p>)
+    output = render("here comes a break:  \nThere it was.")
+
+    assert_equal result, output
+  end
+
+  def test_backslash_escapes_linebreak
+    result = %(<p>here comes a break:<br>\nThere it was.</p>)
+    output = render("here comes a break:\\\nThere it was.")
+
+    assert_equal result, output
+  end
+
+  def test_double_backslash_does_not_escape_linebreak
+    result = %(<p>here comes a backslash, not a break:\\There it was.</p>)
+    output = render("here comes a backslash, not a break:\\There it was.")
+
+    assert_equal result, output
+  end
 end


### PR DESCRIPTION
Other markdown parsers (e.g. flexmark, XCode documentation parser) allow
to add a linebreak by prefixing it with backslash.

This is motivated by downstream bug: https://github.com/realm/jazzy/issues/430