### PR TITLE
Stop newlines from generating invalid html

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -1689,8 +1689,29 @@ parse_paragraph(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t 
 	if (!level) {
 		struct buf *tmp = rndr_newbuf(rndr, BUFFER_BLOCK);
 		parse_inline(tmp, rndr, work.data, work.size);
-		if (rndr->cb.paragraph)
-			rndr->cb.paragraph(ob, tmp, rndr->opaque);
+
+		// If the next tag in content is a closing tag, don't wrap content in a 
+		// <p> block, or the generated html will be invalid
+		int has_orphaned_closing_tag = 0;
+		size_t i;
+		for (i = 0; i < work.size; i++) {
+		if (work.data[i] == '<') {
+			// allow ](</ as a special case to support angle-bracket relative links
+			if ((sizeof(work.data) > i && work.data[i+1] == '/') &&
+				!(i >= 2 && work.data[i-1] == '(' && work.data[i-2] == ']')) {
+				has_orphaned_closing_tag = 1;
+			}
+			break;
+		}
+	}
+
+	if (has_orphaned_closing_tag) {
+		if (rndr->cb.blockhtml)
+			rndr->cb.blockhtml(ob, tmp, rndr->opaque);
+		} else {
+			if (rndr->cb.paragraph)
+				rndr->cb.paragraph(ob, tmp, rndr->opaque);
+		}
 		rndr_popbuf(rndr, BUFFER_BLOCK);
 	} else {
 		struct buf *header_work;

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -427,4 +427,11 @@ class MarkdownTest < Redcarpet::TestCase
 
     assert_match /<table>/, output
   end
+
+  def test_newline_between_closing_tags
+    result = "<div><div></div>\n\nbar</div>"
+    output = render("<div><div></div>\nbar</div>")
+
+    assert_equal result, output
+  end
 end


### PR DESCRIPTION
Here's my crack at fixing https://github.com/vmg/redcarpet/issues/703

Previously, adding `\n` in the middle of html tags would cause the markdown generator to wrap some html fragment in `<p>` tags, often causing the generation of invalid html like this:

`<div><p></div></p>`

This commit adds a check in the paragraph generation code to treat the content as plain html if it begins with a closing html tag.

I'm not thrilled about how I'm detecting closing html tags and differentiating them from angle-bracket relative links like `[a](</link>)` - if there's machinery elsewhere in the codebase for doing that that I missed, I'm very happy to refactor to use that.

