### PR TITLE
Undefine uneeded T_DATA allocators

### DIFF
--- a/ext/redcarpet/rc_markdown.c
+++ b/ext/redcarpet/rc_markdown.c
@@ -176,6 +176,7 @@ void Init_redcarpet()
 	rb_mRedcarpet = rb_define_module("Redcarpet");
 
 	rb_cMarkdown = rb_define_class_under(rb_mRedcarpet, "Markdown", rb_cObject);
+	rb_undef_alloc_func(rb_cMarkdown);
 	rb_define_singleton_method(rb_cMarkdown, "new", rb_redcarpet_md__new, -1);
 	rb_define_method(rb_cMarkdown, "render", rb_redcarpet_md_render, 1);
 

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   s.executables = ["redcarpet"]
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rake", "~> 12.2.1"
-  s.add_development_dependency "rake-compiler", "~> 1.0.3"
-  s.add_development_dependency "test-unit", "~> 3.2.3"
+  s.add_development_dependency "rake", "~> 13"
+  s.add_development_dependency "rake-compiler", "~> 1.1"
+  s.add_development_dependency "test-unit", "~> 3.5"
 end


### PR DESCRIPTION
This is now required to avoid warnings on ruby-head.

See: https://bugs.ruby-lang.org/issues/18007

