### PR TITLE
Exclude test files from the gem package

### DIFF
--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
   # = MANIFEST =
   s.files = %w[
+    CHANGELOG.md
+    CONTRIBUTING.md
     COPYING
     Gemfile
     README.markdown
@@ -27,6 +29,7 @@ Gem::Specification.new do |s|
     ext/redcarpet/houdini_html_e.c
     ext/redcarpet/html.c
     ext/redcarpet/html.h
+    ext/redcarpet/html_block_names.txt
     ext/redcarpet/html_blocks.h
     ext/redcarpet/html_smartypants.c
     ext/redcarpet/markdown.c

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -42,21 +42,6 @@ Gem::Specification.new do |s|
     lib/redcarpet/render_man.rb
     lib/redcarpet/render_strip.rb
     redcarpet.gemspec
-    test/benchmark.rb
-    test/custom_render_test.rb
-    test/fixtures/benchmark.md
-    test/html5_test.rb
-    test/html_render_test.rb
-    test/html_toc_render_test.rb
-    test/markdown_test.rb
-    test/pathological_inputs_test.rb
-    test/redcarpet_bin_test.rb
-    test/redcarpet_compat_test.rb
-    test/safe_render_test.rb
-    test/smarty_html_test.rb
-    test/smarty_pants_test.rb
-    test/stripdown_render_test.rb
-    test/test_helper.rb
   ]
   # = MANIFEST =
   s.test_files = s.files.grep(%r{^test/})


### PR DESCRIPTION
I noticed that the installed redcarpet gem package includes test files that are not usually included in other gems, and misses some documents instead.

So here's a patch that removes the tests and adds three document files.

The reason that I thought why tests are not usually included in other gems is just because [the Bundler "new gem" template](https://github.com/rubygems/rubygems/blob/1e4eda7/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L27-L31) rejects them. However, this does not necessarily mean that a gem should never include tests. So, feel free to ignore or just close this PR if you're intentionally including them and want to keep shipping gems with tests.