### PR TITLE
Unobtrusively support the breaking up of ordered lists without resetting their indices/steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 3.7.0
+
+* Unobtrusively support the breaking up of ordered lists without resetting their indices/steps.
+
+  Fixes #740.
+
+  *Dennis Hackethal*
+
 ## Version 3.6.0
 
 * Avoid warnings running on Ruby 3.2+.

--- a/README.markdown
+++ b/README.markdown
@@ -254,7 +254,7 @@ end
 * header(text, header_level)
 * hrule()
 * list(contents, list_type)
-* list_item(text, list_type)
+* list_item(text, list_type, step)
 * paragraph(text)
 * table(header, body)
 * table_row(content)

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -404,9 +404,14 @@ rndr_list(struct buf *ob, const struct buf *text, int flags, void *opaque)
 }
 
 static void
-rndr_listitem(struct buf *ob, const struct buf *text, int flags, void *opaque)
+rndr_listitem(struct buf *ob, const struct buf *text, int flags, void *opaque, int step)
 {
-	BUFPUTSL(ob, "<li>");
+	if (flags & MKD_LIST_ORDERED) {
+		bufprintf(ob, "<li data-step=\"%d\">", step);
+	} else {
+		BUFPUTSL(ob, "<li>");
+	}
+
 	if (text) {
 		size_t size = text->size;
 		while (size && text->data[size - 1] == '\n')

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -75,7 +75,7 @@ struct sd_callbacks {
 	void (*header)(struct buf *ob, const struct buf *text, int level, void *opaque);
 	void (*hrule)(struct buf *ob, void *opaque);
 	void (*list)(struct buf *ob, const struct buf *text, int flags, void *opaque);
-	void (*listitem)(struct buf *ob, const struct buf *text, int flags, void *opaque);
+	void (*listitem)(struct buf *ob, const struct buf *text, int flags, void *opaque, int step);
 	void (*paragraph)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*table)(struct buf *ob, const struct buf *header, const struct buf *body, void *opaque);
 	void (*table_row)(struct buf *ob, const struct buf *text, void *opaque);

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -86,10 +86,10 @@ rndr_list(struct buf *ob, const struct buf *text, int flags, void *opaque)
 }
 
 static void
-rndr_listitem(struct buf *ob, const struct buf *text, int flags, void *opaque)
+rndr_listitem(struct buf *ob, const struct buf *text, int flags, void *opaque, int step)
 {
-	BLOCK_CALLBACK("list_item", 2, buf2str(text),
-			(flags & MKD_LIST_ORDERED) ? CSTR2SYM("ordered") : CSTR2SYM("unordered"));
+	BLOCK_CALLBACK("list_item", 3, buf2str(text),
+			(flags & MKD_LIST_ORDERED) ? CSTR2SYM("ordered") : CSTR2SYM("unordered"), INT2NUM(step));
 }
 
 static void

--- a/lib/redcarpet.rb
+++ b/lib/redcarpet.rb
@@ -2,7 +2,7 @@ require 'redcarpet.so'
 require 'redcarpet/compat'
 
 module Redcarpet
-  VERSION = '3.6.0'
+  VERSION = '3.7.0'
 
   class Markdown
     attr_reader :renderer

--- a/lib/redcarpet/render_man.rb
+++ b/lib/redcarpet/render_man.rb
@@ -52,10 +52,10 @@ module Redcarpet
         end
       end
 
-      def list_item(content, list_type)
+      def list_item(content, list_type, step)
         case list_type
         when :ordered
-          ".IP \\n+[step]\n#{content.strip}\n"
+          ".IP \\n+[#{step}]\n#{content.strip}\n"
         when :unordered
           ".IP \\[bu] 2 \n#{content.strip}\n"
         end

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -1,10 +1,10 @@
 # encoding: utf-8
 Gem::Specification.new do |s|
   s.name = 'redcarpet'
-  s.version = '3.6.0'
+  s.version = '3.7.0'
   s.summary = "Markdown that smells nice"
   s.description = 'A fast, safe and extensible Markdown to (X)HTML parser'
-  s.date = '2023-01-29'
+  s.date = '2023-08-25'
   s.email = 'vicent@github.com'
   s.homepage = 'https://github.com/vmg/redcarpet'
   s.authors = ["Natacha Porté", "Vicent Martí"]

--- a/test/MarkdownTest_1.0.3/Tests/Ordered and unordered lists.html
+++ b/test/MarkdownTest_1.0.3/Tests/Ordered and unordered lists.html
@@ -57,44 +57,52 @@
 <p>Tight:</p>
 
 <ol>
-<li>First</li>
-<li>Second</li>
-<li>Third</li>
+<li data-step="1">First</li>
+<li data-step="2">Second</li>
+<li data-step="3">Third</li>
 </ol>
 
 <p>and:</p>
 
 <ol>
-<li>One</li>
-<li>Two</li>
-<li>Three</li>
+<li data-step="1">One</li>
+<li data-step="2">Two</li>
+<li data-step="3">Three</li>
 </ol>
 
 <p>Loose using tabs:</p>
 
 <ol>
-<li><p>First</p></li>
-<li><p>Second</p></li>
-<li><p>Third</p></li>
+<li data-step="1"><p>First</p></li>
+<li data-step="2"><p>Second</p></li>
+<li data-step="3"><p>Third</p></li>
 </ol>
 
 <p>and using spaces:</p>
 
 <ol>
-<li><p>One</p></li>
-<li><p>Two</p></li>
-<li><p>Three</p></li>
+<li data-step="1"><p>One</p></li>
+<li data-step="2"><p>Two</p></li>
+<li data-step="3"><p>Three</p></li>
 </ol>
 
 <p>Multiple paragraphs:</p>
 
 <ol>
-<li><p>Item 1, graf one.</p>
+<li data-step="1"><p>Item 1, graf one.</p>
 
 <p>Item 2. graf two. The quick brown fox jumped over the lazy dog's
 back.</p></li>
-<li><p>Item 2.</p></li>
-<li><p>Item 3.</p></li>
+<li data-step="2"><p>Item 2.</p></li>
+<li data-step="3"><p>Item 3.</p></li>
+</ol>
+
+<p>Custom steps:</p>
+
+<ol>
+<li data-step="2">Two</li>
+<li data-step="5">Five</li>
+<li data-step="13">Thirteen</li>
 </ol>
 
 <h2>Nested</h2>
@@ -112,28 +120,28 @@ back.</p></li>
 <p>Here's another:</p>
 
 <ol>
-<li>First</li>
-<li>Second:
+<li data-step="1">First</li>
+<li data-step="2">Second:
 <ul>
 <li>Fee</li>
 <li>Fie</li>
 <li>Foe</li>
 </ul></li>
-<li>Third</li>
+<li data-step="3">Third</li>
 </ol>
 
 <p>Same thing but with paragraphs:</p>
 
 <ol>
-<li><p>First</p></li>
-<li><p>Second:</p>
+<li data-step="1"><p>First</p></li>
+<li data-step="2"><p>Second:</p>
 
 <ul>
 <li>Fee</li>
 <li>Fie</li>
 <li>Foe</li>
 </ul></li>
-<li><p>Third</p></li>
+<li data-step="3"><p>Third</p></li>
 </ol>
 
 
@@ -145,4 +153,27 @@ back.</p></li>
 <ul><li>sub</li></ul>
 
 <p>that</p></li>
+</ul>
+
+<p>Nested custom steps:</p>
+<ol>
+<li data-step="1">First</li>
+<li data-step="2">Second
+<ol>
+<li data-step="5">Nested fifth</li>
+<li data-step="7">Nested seventh</li>
+</ol>
+</li>
+<li data-step="3">Third</li>
+</ol>
+
+<p>Nested custom steps within unordered:</p>
+<ul>
+<li>Foo
+<ol>
+<li data-step="3">Nested third</li>
+<li data-step="7">Nested seventh</li>
+</ol>
+</li>
+<li>Bar</li>
 </ul>

--- a/test/MarkdownTest_1.0.3/Tests/Ordered and unordered lists.text
+++ b/test/MarkdownTest_1.0.3/Tests/Ordered and unordered lists.text
@@ -93,7 +93,11 @@ Multiple paragraphs:
 
 3.	Item 3.
 
+Custom steps:
 
+2. Two
+5. Five
+13. Thirteen
 
 ## Nested
 
@@ -129,3 +133,18 @@ This was an error in Markdown 1.0.1:
 	*	sub
 
 	that
+
+Nested custom steps:
+
+1. First
+2. Second
+	5. Nested fifth
+	7. Nested seventh
+3. Third
+
+Nested custom steps within unordered:
+
+* Foo
+	3. Nested third
+	7. Nested seventh
+* Bar

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -398,8 +398,23 @@ class MarkdownTest < Redcarpet::TestCase
   def test_ordered_lists_with_lax_spacing
     output = render("Foo:\n1. Foo\n2. Bar", with: [:lax_spacing])
 
-    assert_match /<ol>/, output
-    assert_match /<li>Foo<\/li>/, output
+    assert_equal %{<p>Foo:</p>
+
+<ol>
+<li data-step="1">Foo</li>
+<li data-step="2">Bar</li>
+</ol>}, output
+  end
+
+  def test_ordered_lists_with_lax_spacing_and_custom_start
+    output = render("Foo:\n2. Foo\n5. Bar", with: [:lax_spacing])
+
+    assert_equal %{<p>Foo:</p>
+
+<ol>
+<li data-step="2">Foo</li>
+<li data-step="5">Bar</li>
+</ol>}, output
   end
 
   def test_references_with_tabs_after_colon


### PR DESCRIPTION
Markdown is known for resetting the counter on broken-up ordered lists, where this...

```
1. Foo
2. Bar

Some interruption here

3. Baz
```

...turns into...

```
1. Foo
2. Bar

Some interruption here

1. Baz
```

This behavior can be frustrating since markdown blatantly disregards the `3` the user typed and implicitly turns in into a `1`. Various [hacks](https://stackoverflow.com/questions/18088955/markdown-continue-numbered-list) have been suggested, but none of them are exactly satisfying.

This PR fixes the issue by associating each `li` in an ordered list with an explicit `data-step` that is based on the number the user typed:

```html
<ol>
  <li data-step="1">Foo</li>
  <li data-step="2">Bar</li>
</ol>

<p>Some interruption here</p>

<ol>
  <li data-step="3">Baz</li>
</ol>
```

This change is probably backwards compatible for consumers since it is unlikely that they depend on a `data-step` attribute on `li` elements already. Nor do `data` attributes change UIs in any way unless configured to do so – they are generally unobtrusive.

Consumers can opt in to the new behavior with this simple CSS:

```css
li[data-step]::marker {
  content: attr(data-step) '. ';
}
```

However, on the producer side, those who override the `list_item` method will need to add a `step` parameter to support the new 3-arity:

```ruby
def list_item text, list_type, step = nil
  # ...
end
```

Therefore, this PR introduces a breaking change – hence the new major version 7.

For unordered lists, the `step` parameter can simply be disregarded by producers (though it is still passed to `list_item` but should always be `0`). It does not make it to the consumer, ie no `li` elements in unordered lists ever have any `data-step` attribute.

I have no experience writing C and took a bunch of educated guesses with the help of AI. Please take a close look at the proposed changes. I did add tests and they all pass for me; I've also tested the behavior on a site for which I use the gem and it seems to work fine.

If this PR isn't satisfactory, an alternative implementation to consider is to add a `start` attribute to the `ol` based on the first list item's number. Something like...

```md
5. Foo
6. Bar
```

...turning into:

```html
<ol start="5">
  <li>Foo</li>
  <li>Bar</li>
</ol>
```

I see that's how GitHub does it. However, I believe this approach would make turning HTML back into markdown more difficult. In addition, the consumer-side wouldn't be backwards compatible.
