### PR TITLE
Table caption

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -257,6 +257,7 @@ end
 * list_item(text, list_type)
 * paragraph(text)
 * table(header, body)
+* table_caption(content)
 * table_row(content)
 * table_cell(content, alignment, header)
 

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -567,16 +567,28 @@ rndr_raw_html(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static void
-rndr_table(struct buf *ob, const struct buf *header, const struct buf *body, void *opaque)
+rndr_table(struct buf *ob, const struct buf *caption, const struct buf *header, const struct buf *body, void *opaque)
 {
 	if (ob->size) bufputc(ob, '\n');
-	BUFPUTSL(ob, "<table><thead>\n");
+	BUFPUTSL(ob, "<table><caption>\n");
+	if (caption)
+		bufput(ob, caption->data, caption->size);
+	BUFPUTSL(ob, "</caption><thead>\n");
 	if (header)
 		bufput(ob, header->data, header->size);
 	BUFPUTSL(ob, "</thead><tbody>\n");
 	if (body)
 		bufput(ob, body->data, body->size);
 	BUFPUTSL(ob, "</tbody></table>\n");
+}
+
+static void
+rndr_tablecaption(struct buf *ob, const struct buf *text, void *opaque)
+{
+	BUFPUTSL(ob, "<caption>\n");
+	if (text)
+		bufput(ob, text->data, text->size);
+	BUFPUTSL(ob, "</caption>\n");
 }
 
 static void
@@ -774,6 +786,7 @@ sdhtml_toc_renderer(struct sd_callbacks *callbacks, struct html_renderopt *optio
 		NULL,
 		NULL,
 		NULL,
+		NULL,
 		rndr_footnotes,
 		rndr_footnote_def,
 
@@ -819,6 +832,7 @@ sdhtml_renderer(struct sd_callbacks *callbacks, struct html_renderopt *options, 
 		rndr_listitem,
 		rndr_paragraph,
 		rndr_table,
+		rndr_tablecaption,
 		rndr_tablerow,
 		rndr_tablecell,
 		rndr_footnotes,

--- a/ext/redcarpet/html.c
+++ b/ext/redcarpet/html.c
@@ -570,10 +570,10 @@ static void
 rndr_table(struct buf *ob, const struct buf *caption, const struct buf *header, const struct buf *body, void *opaque)
 {
 	if (ob->size) bufputc(ob, '\n');
-	BUFPUTSL(ob, "<table><caption>\n");
+	BUFPUTSL(ob, "<table>\n");
 	if (caption)
 		bufput(ob, caption->data, caption->size);
-	BUFPUTSL(ob, "</caption><thead>\n");
+	BUFPUTSL(ob, "<thead>\n");
 	if (header)
 		bufput(ob, header->data, header->size);
 	BUFPUTSL(ob, "</thead><tbody>\n");

--- a/ext/redcarpet/markdown.h
+++ b/ext/redcarpet/markdown.h
@@ -77,7 +77,8 @@ struct sd_callbacks {
 	void (*list)(struct buf *ob, const struct buf *text, int flags, void *opaque);
 	void (*listitem)(struct buf *ob, const struct buf *text, int flags, void *opaque);
 	void (*paragraph)(struct buf *ob, const struct buf *text, void *opaque);
-	void (*table)(struct buf *ob, const struct buf *header, const struct buf *body, void *opaque);
+	void (*table)(struct buf *ob, const struct buf *caption, const struct buf *header, const struct buf *body, void *opaque);
+	void (*table_caption)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*table_row)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*table_cell)(struct buf *ob, const struct buf *text, int flags, void *opaque);
 	void (*footnotes)(struct buf *ob, const struct buf *text, void *opaque);

--- a/ext/redcarpet/rc_render.c
+++ b/ext/redcarpet/rc_render.c
@@ -99,9 +99,15 @@ rndr_paragraph(struct buf *ob, const struct buf *text, void *opaque)
 }
 
 static void
-rndr_table(struct buf *ob, const struct buf *header, const struct buf *body, void *opaque)
+rndr_table(struct buf *ob, const struct buf *caption, const struct buf *header, const struct buf *body, void *opaque)
 {
-	BLOCK_CALLBACK("table", 2, buf2str(header), buf2str(body));
+	BLOCK_CALLBACK("table", 3, buf2str(caption), buf2str(header), buf2str(body));
+}
+
+static void
+rndr_tablecaption(struct buf *ob, const struct buf *text, void *opaque)
+{
+	BLOCK_CALLBACK("table_caption", 1, buf2str(text));
 }
 
 static void
@@ -320,6 +326,7 @@ static struct sd_callbacks rb_redcarpet_callbacks = {
 	rndr_listitem,
 	rndr_paragraph,
 	rndr_table,
+	rndr_tablecaption,
 	rndr_tablerow,
 	rndr_tablecell,
 	rndr_footnotes,
@@ -358,6 +365,7 @@ static const char *rb_redcarpet_method_names[] = {
 	"list_item",
 	"paragraph",
 	"table",
+	"table_caption",
 	"table_row",
 	"table_cell",
 	"footnotes",
@@ -383,8 +391,7 @@ static const char *rb_redcarpet_method_names[] = {
 	"normal_text",
 
 	"doc_header",
-	"doc_footer"
-};
+	"doc_footer"};
 
 static const size_t rb_redcarpet_method_count = sizeof(rb_redcarpet_method_names)/sizeof(char *);
 

--- a/lib/redcarpet/render_strip.rb
+++ b/lib/redcarpet/render_strip.rb
@@ -44,8 +44,12 @@ module Redcarpet
         text + "\n"
       end
 
-      def table(header, body)
-        "#{header}#{body}"
+      def table(caption, header, body)
+        "#{caption}#{header}#{body}"
+      end
+
+      def table_caption(content)
+        content + "\n"
       end
 
       def table_row(content)

--- a/test/stripdown_render_test.rb
+++ b/test/stripdown_render_test.rb
@@ -51,6 +51,20 @@ class StripDownRender < Redcarpet::TestCase
     assert_equal expected, output
   end
 
+  def test_tables_with_caption
+    markdown = "| # Caption Goes Here |\n" \
+               "| Left-Aligned  | Centre Aligned  | Right Aligned |\n" \
+               "| :------------ |:---------------:| -----:|\n" \
+               "| col 3 is      | some wordy text | $1600 |\n" \
+               "| col 2 is      | centered        |   $12 |"
+    expected = "Left-Aligned\tCentre Aligned\tRight Aligned\t\n" \
+               "col 3 is\tsome wordy text\t$1600\t\n" \
+               "col 2 is\tcentered\t$12\t"
+    output   = render(markdown, with: [:tables])
+
+    assert_equal expected, output
+  end
+
   def test_highlight
     markdown = "==Hello world!=="
     expected = "Hello world!"

--- a/test/stripdown_render_test.rb
+++ b/test/stripdown_render_test.rb
@@ -57,7 +57,8 @@ class StripDownRender < Redcarpet::TestCase
                "| :------------ |:---------------:| -----:|\n" \
                "| col 3 is      | some wordy text | $1600 |\n" \
                "| col 2 is      | centered        |   $12 |"
-    expected = "Left-Aligned\tCentre Aligned\tRight Aligned\t\n" \
+    expected = "Caption Goes Here\n" \
+               "Left-Aligned\tCentre Aligned\tRight Aligned\t\n" \
                "col 3 is\tsome wordy text\t$1600\t\n" \
                "col 2 is\tcentered\t$12\t"
     output   = render(markdown, with: [:tables])


### PR DESCRIPTION
I understand this PR might be unwanted and surely unexpected, but I needed this for my own work and I find it useful to at least provide a PR so that the code might be used by those needing the same functionality.

Basically, it allows `<caption>` to be added to tables in the following way:

```markdown
| # Table Caption |
| Head 1 | Head 2|
| ------ | ------ |
| Cell 1 | Cell 2| 
| Cell 3 | Cell 4| 
```

It’s fully backward compatible and the caption would be recognized if it only goes as the first line in the table _and_ starts with a hash symbol.

WDYT?