### PR TITLE
Convert Markdown objects to TypedData API

### DIFF
--- a/ext/redcarpet/redcarpet.h
+++ b/ext/redcarpet/redcarpet.h
@@ -49,4 +49,6 @@ struct rb_redcarpet_rndr {
 	struct redcarpet_renderopt options;
 };
 
+struct rb_redcarpet_rndr * rb_redcarpet_rndr_unwrap(VALUE);
+
 #endif


### PR DESCRIPTION
The replacement API was introduced in Ruby 1.9.2 (2010), and the old untyped data API was marked a deprecated in the documentation as of Ruby 2.3.0 (2015)

Ref: https://bugs.ruby-lang.org/issues/19998