### PR TITLE
Allow 2-space indentation for multi-p li items

### DIFF
--- a/ext/redcarpet/markdown.c
+++ b/ext/redcarpet/markdown.c
@@ -1937,7 +1937,8 @@ parse_listitem(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t s
 				sublist = work->size;
 		}
 		/* joining only indented stuff after empty lines */
-		else if (in_empty && i < 4 && data[beg] != '\t') {
+		/* Indentation must be by 2 spaces or more */
+		else if (in_empty && i < 2 && data[beg] != '\t') {
 			*flags |= MKD_LI_END;
 			break;
 		}

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -86,13 +86,13 @@ class MarkdownTest < Redcarpet::TestCase
   end
 
   # https://github.com/vmg/redcarpet/issues/111
-  def test_p_with_less_than_4space_indent_should_not_be_part_of_last_list_item
+  def test_p_with_less_than_2space_indent_should_not_be_part_of_last_list_item
     text = <<-Markdown
   * a
   * b
   * c
 
-  This paragraph is not part of the list.
+ This paragraph is not part of the list.
     Markdown
     expected = <<-HTML.chomp.strip_heredoc
       <ul>


### PR DESCRIPTION
Other implementations of markdown allow for smaller indentations to
indicate the continuation of a list item, whereas the main redcarpet
repository enforces at least 4 spaces.

The particular motivation for this change was that we've switched our
curriculum repository to use mdformat, which always reformats list items
to match the level of indentation of the list indicator (2 for "* ", 3
for "1. " etc.). This will always be at least 2 spaces.

Note: This generally feels a bit hacky, in that the indentation is taken
relative to the LHS, rather than relative to the previous bullet point.
However, I'm not planning on fixing this unintuitive behaviour for now,
this small change should do what we need (and tests still pass).
