### PR TITLE
Add missing metadata to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Master (Unreleased)
+
+* Add missing gemspec metadata.
+
+  Refs #800.
+
+  *Nate Eizenga*
+
 ## Version 3.6.1
 
 * Migrate Markdown objects to the `TypedData` API.

--- a/redcarpet.gemspec
+++ b/redcarpet.gemspec
@@ -7,6 +7,13 @@ Gem::Specification.new do |s|
   s.date = '2025-02-25'
   s.email = 'vicent@github.com'
   s.homepage = 'https://github.com/vmg/redcarpet'
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/vmg/redcarpet/issues",
+    "changelog_uri"     => "https://github.com/vmg/redcarpet/blob/master/CHANGELOG.md",
+    "homepage_uri"      => "https://github.com/vmg/redcarpet",
+    "source_code_uri"   => "https://github.com/vmg/redcarpet",
+    "wiki_uri"          => "https://github.com/vmg/redcarpet/wiki",
+  }
   s.authors = ["Natacha Porté", "Vicent Martí"]
   s.license = 'MIT'
   s.required_ruby_version = '>= 1.9.2'


### PR DESCRIPTION
Did my best to fill out the metadata for your gem. In particular this causes e.g. the changelog to be linked in the sidebar of https://rubygems.org/gems/redcarpet, which makes auditing gem updates a much easier task